### PR TITLE
Capture plugin fixes

### DIFF
--- a/nose2/plugins/buffer.py
+++ b/nose2/plugins/buffer.py
@@ -6,7 +6,7 @@ This allows you to use print for debugging in tests without making
 your test runs noisy.
 
 This plugin implements :func:`startTest`, :func:`stopTest`,
-:func:`testOutcome`, :func:`outcomeDetail`, :func:`beforeInteraction`
+:func:`setTestOutcome`, :func:`outcomeDetail`, :func:`beforeInteraction`
 and :func:`afterInteraction` to manage capturing sys.stdout and/or
 sys.stderr into buffers, attaching the buffered output to test error
 report detail, and getting out of the way when other plugins want to

--- a/nose2/plugins/logcapture.py
+++ b/nose2/plugins/logcapture.py
@@ -3,7 +3,7 @@ Capture log messages during test execution, appending them to the
 error reports of failed tests.
 
 This plugin implements :func:`startTestRun`, :func:`startTest`,
-:func:`stopTest`, :func:`testOutcome`, and :func:`outcomeDetail` to
+:func:`stopTest`, :func:`setTestOutcome`, and :func:`outcomeDetail` to
 set up a logging configuration that captures log messages during test
 execution, and appends them to error reports for tests that fail or
 raise exceptions.


### PR DESCRIPTION
Fixes for logcapture and output buffer plugins. Plugins shouldn't set things in TestOutcome that other plugins might want to see, since plugin ordering is unreliable. So this diff switches both of the plugins to setTestOutcome, and updates their docstrings. Tests for logcapture are updated, and tests for buffer are added since there currently aren't any.
