### PR TITLE
Provide discovery-only version of nose2.main (nose2.discover) [Fixes #32]

### DIFF
--- a/bin/nose2
+++ b/bin/nose2
@@ -2,6 +2,6 @@
 
 __unittest = True
 
-from nose2.main import main_
+from nose2 import discover
 
-main_()
+discover()

--- a/nose2/__init__.py
+++ b/nose2/__init__.py
@@ -1,1 +1,1 @@
-from nose2.main import main_
+from nose2.main import discover, main

--- a/nose2/__main__.py
+++ b/nose2/__main__.py
@@ -6,5 +6,5 @@ if sys.argv[0].endswith("__main__.py"):
 
 __unittest = True
 
-from nose2.main import main_
-main_()
+from nose2 import discover
+discover()

--- a/nose2/main.py
+++ b/nose2/main.py
@@ -215,10 +215,6 @@ class PluggableTestProgram(unittest.TestProgram):
 
     def createTests(self):
         """Create top-level test suite"""
-        # XXX belongs in init?
-        if self.module and '__unittest' in dir(self.module):
-            self.module = None
-
         event = events.CreateTestsEvent(
            self.testLoader, self.testNames, self.module)
         result = self.session.hooks.createTests(event)
@@ -244,4 +240,9 @@ class PluggableTestProgram(unittest.TestProgram):
         return event.runner
 
 
-main_ = PluggableTestProgram
+main = PluggableTestProgram
+
+
+def discover(*args, **kwargs):
+    kwargs['module'] = None
+    return main(*args, **kwargs)

--- a/nose2/tests/_common.py
+++ b/nose2/tests/_common.py
@@ -3,12 +3,11 @@ import os.path
 import tempfile
 import shutil
 import sys
-import subprocess
 
 import six
 
 from nose2.compat import unittest
-from nose2 import main, util
+from nose2 import discover, util
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -167,7 +166,7 @@ class NotReallyAProc(object):
     def communicate(self):
         with self:
             try:
-                self.result = main.PluggableTestProgram(
+                self.result = discover(
                     argv=('nose2',) + self.args, exit=False,
                     **self.kwargs)
             except SystemExit as e:

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,8 @@ else:
 
     params['entry_points'] = {
         'console_scripts': [
-            '%s = nose2:main_' % SCRIPT1,
-            '%s = nose2:main_' % SCRIPT2,
+            '%s = nose2:discover' % SCRIPT1,
+            '%s = nose2:discover' % SCRIPT2,
         ],
     }
     params['install_requires'] = REQS


### PR DESCRIPTION
Provisional fix for #32.

nose2.main is now analagous to unittest.main -- for use in single modules. nose2.discover is analagous to unit2 discover and is now called by the nose2 command line script and setuptools scripts.
