### PR TITLE
Extra hooks [Fixes #31]

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -176,11 +176,11 @@ exclude (``excludedPlugins``). You can also subclass
 ``defaultPlugins`` and ``excludePlugins`` attributes to alter plugin
 loading.
 
-Setting Extra Hooks
-^^^^^^^^^^^^^^^^^^^
+When Loading Plugins from Modules is not Enough
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **None of which will help** if you need to register a plugin *instance*
-that you've loaded yourself. For that, use the ``hooks`` keyword
+that you've loaded yourself. For that, use the ``extraHooks`` keyword
 argument to ``nose2.discover``. Here, you pass in a list of 2-tuples,
 each of which contains a hook name and a plugin *instance* to register
 for that hook. This allows you to register plugins that need runtime
@@ -195,7 +195,7 @@ targets. Here's a trivial example::
         def startTestRun(self, event):
             print("hello!")
 
-    nose2.discover(hooks=[('startTestRun', Hello())])
+    nose2.discover(extraHooks=[('startTestRun', Hello())])
 
 This can come in handy when integrating with other systems that expect
 you to provide a test runner that they execute, rather than executing

--- a/nose2/main.py
+++ b/nose2/main.py
@@ -29,10 +29,10 @@ class PluggableTestProgram(unittest.TestProgram):
     :param buffer: *IGNORED*
     :param plugins: List of additional plugin modules to load
     :param excludePlugins: List of plugin modules to exclude
-    :param hooks: List of hook names and plugin *instances* to
-                  register with the session's hooks system. Each
-                  item in the list must be a 2-tuple of
-                  (hook name, plugin instance)
+    :param extraHooks: List of hook names and plugin *instances* to
+                       register with the session's hooks system. Each
+                       item in the list must be a 2-tuple of
+                       (hook name, plugin instance)
 
     .. attribute :: sessionClass
 
@@ -87,10 +87,10 @@ class PluggableTestProgram(unittest.TestProgram):
     def __init__(self, **kw):
         plugins = kw.pop('plugins', [])
         exclude = kw.pop('excludePlugins', [])
-        hooks = kw.pop('hooks', [])
+        hooks = kw.pop('extraHooks', [])
         self.defaultPlugins = list(self.defaultPlugins)
         self.excludePlugins = list(self.excludePlugins)
-        self.hooks = hooks
+        self.extraHooks = hooks
         self.defaultPlugins.extend(plugins)
         self.excludePlugins.extend(exclude)
         super(PluggableTestProgram, self).__init__(**kw)
@@ -232,7 +232,7 @@ class PluggableTestProgram(unittest.TestProgram):
 
         """
         self.session.loadPlugins(self.defaultPlugins, self.excludePlugins)
-        for method_name, plugin in self.hooks:
+        for method_name, plugin in self.extraHooks:
             self.session.hooks.register(method_name, plugin)
 
     def createTests(self):

--- a/nose2/tests/functional/test_main.py
+++ b/nose2/tests/functional/test_main.py
@@ -14,7 +14,8 @@ class TestPluggableTestProgram(FunctionalTestCase):
                 self.ran = True
 
         check = Check()
-        proc = self.runIn('scenario/no_tests', hooks=[('startTestRun', check)])
+        proc = self.runIn('scenario/no_tests',
+                          extraHooks=[('startTestRun', check)])
         stdout, stderr = proc.communicate()
         self.assertEqual(proc.poll(), 0, stderr)
         assert check.ran, "Extra hook did not execute"


### PR DESCRIPTION
Implementation, docs and tests for a 'hooks' kwarg for PluggableTestProgram. This kwarg allows users who are rolling their own runner scripts to register objects to receive hook calls. This is useful for cases like django where we want to provide a test runner for someone else to run, and sometimes have to configure things at runtime based on arguments to the function/method that returns the test runner.
