### PR TITLE
Add py33 to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py32,pypy,docs,self26,cov26
+envlist=py26,py27,py32,py33,pypy,docs,self26,cov26
 
 [testenv:docs]
 basepython=python2.7
@@ -26,6 +26,11 @@ deps=-r{toxinidir}/requirements.txt
 commands=python -m unittest discover []
 
 [testenv:py32]
+deps=-r{toxinidir}/requirements.txt
+     -r{toxinidir}/requirements-docs.txt
+commands=python -m unittest discover []
+
+[testenv:py33]
 deps=-r{toxinidir}/requirements.txt
      -r{toxinidir}/requirements-docs.txt
 commands=python -m unittest discover []


### PR DESCRIPTION
py33 was added in the most recent version of tox (see http://tox.testrun.org/latest/changelog.html)

tox output:

```
~/dev/git-repos/nose2$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  py32: commands succeeded
  py33: commands succeeded
  pypy: commands succeeded
  docs: commands succeeded
  self26: commands succeeded
  cov26: commands succeeded
  congratulations :)
```

```
~/dev/git-repos/nose2$ pip freeze | grep tox
Warning: cannot find svn location for INITools==0.3.1dev-r0
detox==0.9
-e git+https://github.com/msabramo/piptox.git@adef3b7826a42b89d74868f56c46e4a43bfd2fc6#egg=piptox-dev
tox==1.4
```

Passing Travis build: http://travis-ci.org/#!/msabramo/nose2/builds/1635897
