### PR TITLE
Missing files and back up files in PyPI 0.4 tarball.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 
 NAME = 'nose2'
 VERSION = '0.4'
-PACKAGES = ['nose2', 'nose2.plugins', 'nose2.plugins.loader',
+PACKAGES = ['nose2', 'nose2.plugins', 'nose2.plugins.loader', 'nose2.tools',
             'nose2.tests', 'nose2.tests.functional', 'nose2.tests.unit']
 SCRIPTS = ['bin/nose2']
 DESCRIPTION = 'nose2 is the next generation of nicer testing for Python'


### PR DESCRIPTION
It looks like something went awry for the tarball generation.  The `nose2.tools` files are missing in the release, and tarball is cluttered with editor backup files.  The massive(compared to the rest of the package) sphinx doctree are also included for some reason, although maybe I'm just missing the obvious reason for included the Sphinx output ;)

The simple workaround should others face the same problem is just to use the [tag downloads](https://github.com/nose-devs/nose2/tags) from github.
