### PR TITLE
Only call layer-leve fixture methods explicitly defined on layer classes

### DIFF
--- a/nose2/suite.py
+++ b/nose2/suite.py
@@ -58,7 +58,7 @@ class LayerSuite(unittest.BaseTestSuite):
             # suite-like enough for skipping
             return
 
-        setup = self._get_bound_classmethod(self.layer, 'testSetUp')
+        setup = getattr(self.layer, 'testSetUp', None)
         if setup:
             if getattr(test, '_layer_wasSetUp', False):
                 return
@@ -75,7 +75,7 @@ class LayerSuite(unittest.BaseTestSuite):
             return
         if not getattr(test, '_layer_wasSetUp', None):
             return
-        teardown = self._get_bound_classmethod(self.layer, 'testTearDown')
+        teardown = getattr(self.layer, 'testTearDown', None)
         if teardown:
             args, _, _, _ = inspect.getargspec(teardown)
             if len(args) > 1:

--- a/nose2/tests/functional/support/scenario/layers_with_inheritance/test_layers_with_inheritance.py
+++ b/nose2/tests/functional/support/scenario/layers_with_inheritance/test_layers_with_inheritance.py
@@ -4,29 +4,25 @@ from nose2.compat import unittest
 class L1(object):
     @classmethod
     def setUp(cls):
-        print('L1setUp')
-
-    @classmethod
-    def testSetUp(cls):
-        print('L1testSetUp')
+        print('L1 setUp')
 
     @classmethod
     def tearDown(cls):
-        print('L1tearDown')
-
-    @classmethod
-    def testTearDown(cls):
-        print('L1testTearDown')
+        print('L1 tearDown')
 
 
 class L2(L1):
     @classmethod
     def setUp(cls):
-        print('L2setUp')
+        print('L2 setUp')
 
     @classmethod
     def testSetUp(cls):
-        print('L2testSetUp')
+        print('L2 testSetUp')
+
+    @classmethod
+    def testTearDown(cls):
+        print('L2 testTearDown')
 
 
 # L1 tearDown should only run once
@@ -34,7 +30,7 @@ class T1(unittest.TestCase):
     layer = L2
 
     def test1(self):
-        pass
+        print('Run test1')
 
     def test2(self):
-        pass
+        print('Run test2')

--- a/nose2/tests/functional/test_layers_plugin.py
+++ b/nose2/tests/functional/test_layers_plugin.py
@@ -25,12 +25,20 @@ class TestLayers(FunctionalTestCase):
             '-v',
             '--plugin=nose2.plugins.layers')
 
-        expected = ('L1setUp\n'
-                    'L2setUp\n'
-                    'L1testSetUp\n'
-                    'L2testSetUp\n'
-                    'L1testTearDown\n'
-                    'L1tearDown\n$')
+        expected = ('^'
+                    'L1 setUp\n'
+                    'L2 setUp\n'
+
+                    'L2 testSetUp\n'
+                    'Run test1\n'
+                    'L2 testTearDown\n'
+
+                    'L2 testSetUp\n'
+                    'Run test2\n'
+                    'L2 testTearDown\n'
+
+                    'L1 tearDown\n'
+                    '$')
         self.assertTestRunOutputMatches(proc, stdout=expected)
         self.assertEqual(proc.poll(), 0)
 


### PR DESCRIPTION
If a layer inherits setUp or tearDown from another layer, don't call these inherited fixutre methods.  Only call setUp and tearDown if they are explicitly defined on the layer class itself.
