### PR TITLE
junitxmlreporter: All control structures of _time() should return values

### DIFF
--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -129,6 +129,7 @@ class JUnitXmlReporter(events.Plugin):
             pass
         finally:
             self._start = None
+        return 0
 
 #
 # xml utility functions


### PR DESCRIPTION
In case of exception, function _time() doesn't return anything,
and this causes float conversion failure at L:61
