### PR TITLE
Fix for DeprecationWarning on python 2.7 (issue #64)

### DIFF
--- a/nose2/util.py
+++ b/nose2/util.py
@@ -11,15 +11,14 @@ import sys
 import traceback
 
 try:
-    from compiler.consts import CO_GENERATOR
-except ImportError:
-    # IronPython doesn't have a complier module
-    CO_GENERATOR=0x20
-
-try:
     from inspect import isgeneratorfunction # new in 2.6
 except ImportError:
     import inspect
+    try:
+        from compiler.consts import CO_GENERATOR
+    except ImportError:
+        # IronPython doesn't have a complier module
+        CO_GENERATOR=0x20
     # backported from Python 2.6
     def isgeneratorfunction(func):
         return bool((inspect.isfunction(func) or inspect.ismethod(func)) and


### PR DESCRIPTION
nose2/util.py:14: DeprecationWarning: The compiler package is deprecated
and removed in Python 3.x.

  from compiler.consts import CO_GENERATOR
