### PR TITLE
fix a few spelling mistakes in docs and examples

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -69,7 +69,7 @@ Changelog
   from ordinary classes that are not subclasses of unittest.TestCase.
 
 * The default script target was changed from ``nose2.main`` to ``nose2.discover``.
-  The former may still be used for running a single module of teststs,
+  The former may still be used for running a single module of tests,
   unittest-style. The latter ignores the ``module`` argument. Thanks to
   @dtcaciuc for the bug report (#32).
 

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -58,7 +58,7 @@ merges.
 
 Also, core devs should not merge their own work -- again, unless it's
 trivial -- without giving other developers a chance to review it. The
-basic worfklow should be to do the work in a topic branch in your fork
+basic workflow should be to do the work in a topic branch in your fork
 then post a pull request for that branch, whether you're a core
 developer or other contributor.
 

--- a/docs/dev/hook_reference.rst
+++ b/docs/dev/hook_reference.rst
@@ -18,7 +18,7 @@ Pre-registration Hooks
    (those that call :meth:`nose2.events.Plugin.register` in __init__
    or have ``always-on = True`` set in their config file sections) will
    have already been registered with the hooks they implement. Plugins
-   waiting for commmand-line activation will not yet be registered.
+   waiting for command-line activation will not yet be registered.
 
    Plugins can use this hook to examine or modify the set of loaded plugins,
    inject their own hook methods using
@@ -108,7 +108,7 @@ These hooks are called for registered plugins only.
    Plugins can use this hook to load tests from test modules. To
    prevent other plugins from loading from the module, set
    ``event.handled`` and return a test suite. Plugins can also append
-   tests to ``event.extraTests`` -- ususally that's what you want to
+   tests to ``event.extraTests`` -- usually that's what you want to
    do, since that will allow other plugins to load their tests from
    the module as well.
 
@@ -123,7 +123,7 @@ These hooks are called for registered plugins only.
    :class:`unittest.TestCase`. To prevent other plugins from loading
    tests from the test case, set ``event.handled`` to True and return
    a test suite. Plugins can also append tests to ``event.extraTests``
-   -- ususally that's what you want to do, since that will allow other
+   -- usually that's what you want to do, since that will allow other
    plugins to load their tests from the test case as well.
 
 .. function :: getTestCaseNames(self, event)

--- a/docs/differences.rst
+++ b/docs/differences.rst
@@ -57,7 +57,7 @@ Parameterized and Generator Tests
 nose2 supports *more kinds of parameterized and generator tests than
 nose*, and supports all test generators in test functions, test
 classes, and in unittest TestCase subclasses. nose supports them only
-in test fuctions and test classes that do not subclass
+in test functions and test classes that do not subclass
 unittest.TestCase. See: :doc:`plugins/generators` and
 :doc:`plugins/parameters` for more.
 

--- a/docs/plugins/layers.rst
+++ b/docs/plugins/layers.rst
@@ -8,7 +8,7 @@ Organizing Test Fixtures into Layers
 
 Layers allow more flexible organization of test fixtures than test-,
 class- and module- level fixtures. Layers in nose2 are inspired by
-and aim to be compatible with the layers used by zope's testrunner.
+and aim to be compatible with the layers used by Zope's testrunner.
 
 Using layers, you can do things like:
 
@@ -96,7 +96,7 @@ Layer method reference
 
 .. class :: Layer
 
-   Not an acutal class, but reference documentation for
+   Not an actual class, but reference documentation for
    the methods layers can implement. There is no layer
    base class. Layers must be subclasses of :class:`object`
    or other layers.
@@ -209,7 +209,7 @@ Mixing layers with setUpClass and module fixtures
 **Don't cross the streams.**
 
 The implementation of class- and module-level fixtures in unittest2
-depends on introspecting the class heirarchy inside of the
+depends on introspecting the class hierarchy inside of the
 unittest.TestSuite. Since the suites that the layers plugin uses to
 organize tests derive from :class:`unittest.BaseTestSuite` not
 :class:`unittest.TestSuite`, class- and module- level fixtures in
@@ -219,7 +219,7 @@ Mixing layers and multiprocess testing
 --------------------------------------
 
 In the initial release, *test suites using layers are incompatible with
-the multipprocess plugin*. This should be fixed in a future release.
+the multiprocess plugin*. This should be fixed in a future release.
 
 
 Plugin reference

--- a/docs/plugins/mp.rst
+++ b/docs/plugins/mp.rst
@@ -41,7 +41,7 @@ config file::
    If you make the plugin always active by setting ``always-on`` in
    the ``[multiprocess]`` section of a config file, but do not set
    ``processes`` or pass :option:`-N`, the number of processes
-   defaults to the number of cpus available.
+   defaults to the number of CPUs available.
 
 Guidelines for Test Authors
 ---------------------------

--- a/nose2/tools/params.py
+++ b/nose2/tools/params.py
@@ -21,7 +21,7 @@ def params(*paramList):
 
       @params(1, 2, 3)
       def test_nums(num):
-          asset num < 4
+          assert num < 4
 
 
       class Test(unittest.TestCase):


### PR DESCRIPTION
I spotted a mistake in the params plugins example and thought when fixing that I might as well run ispell through the docs dir.
