### PR TITLE
Former syntax is invalid in Python 3

### DIFF
--- a/nose2/plugins/printhooks.py
+++ b/nose2/plugins/printhooks.py
@@ -54,7 +54,7 @@ class NoisyHook(events.Hook):
 
 
 def _report(method, event):
-    print >> sys.stderr, "\n%s%s: %s" % (''.join(INDENT), method, event)
+    sys.stderr.write("\n%s%s: %s" % (''.join(INDENT), method, event, file=sys.stderr)
 
 
 def _indent():


### PR DESCRIPTION
Since the old >> syntax does not work for Python 3 I changed the code to write to stderr instead.
