### PR TITLE
Fix Python 3.3 the keys order is non-deterministic bug

### DIFF
--- a/nose2/plugins/mp.py
+++ b/nose2/plugins/mp.py
@@ -126,9 +126,10 @@ class MultiProcess(events.Plugin):
                             []).append(testid)
                     else:
                         yield testid
-        for cls in classes.keys():
+
+        for cls in sorted(classes.keys()):
             yield cls
-        for mod in mods.keys():
+        for mod in sorted(mods.keys()):
             yield mod
 
     def _localize(self, event):

--- a/nose2/tests/functional/test_mp_plugin.py
+++ b/nose2/tests/functional/test_mp_plugin.py
@@ -67,8 +67,8 @@ class TestMpPlugin(FunctionalTestCase):
         flat = list(self.plugin._flatten(suite))
         self.assertEqual(flat, ['test_cf_testcase.Test2.test_1',
                                 'test_cf_testcase.Test2.test_2',
-                                'test_cf_testcase.Test3',
                                 'test_cf_testcase.Test',
+                                'test_cf_testcase.Test3',
                                 ])
 
 


### PR DESCRIPTION
Fix Python 3.3 the keys order is non-deterministic bug (see https://github.com/nose-devs/nose2/issues/97#issuecomment-20937342)
