### PR TITLE
fix invalid syntax in printhooks

### DIFF
--- a/nose2/plugins/printhooks.py
+++ b/nose2/plugins/printhooks.py
@@ -56,7 +56,7 @@ class NoisyHook(events.Hook):
 
 
 def _report(method, event):
-    sys.stderr.write("\n%s%s: %s" % (''.join(INDENT), method, event, file=sys.stderr)
+    sys.stderr.write("\n%s%s: %s" % (''.join(INDENT), method, event))
 
 
 def _indent():


### PR DESCRIPTION
I can't build a debian package from master at the moment as the printhooks plugin isn't valid python.
