### PR TITLE
Fix a unicode-related crash in output buffering (-B) on Python 2.6

### DIFF
--- a/nose2/util.py
+++ b/nose2/util.py
@@ -293,7 +293,10 @@ class _WritelnDecorator(object):
 
     def writeln(self, arg=None):
         if arg:
-            self.stream.write(arg)
+            if sys.version_info[0] == 2 and sys.version_info[1] < 7:
+                self.stream.write(arg.encode(getattr(self.stream, 'encoding', 'utf-8')))
+            else:
+                self.stream.write(arg)
         self.stream.write('\n')
                           # text-mode streams translate to \r\n if needed
 


### PR DESCRIPTION
This pull request is likely a fix for https://github.com/nose-devs/nose2/issues/116

Python 2.6 does not honour the encoding attribute of sys.std{out|err},
when calling .write(), causing it to fail with a UnicodeEncodeError
if a unicode object containing non-ASCII characters is passed in.

See http://bugs.python.org/issue4947 for more details.

This patch works around the problem by always encoding according to
.encoding, optionally falling back to UTF-8 if it is None.

Note: this problem can be easily reproduced by running  the following 
test snippet with: nose2 -B unicode_test

``` python
#!/usr/bin/python
# -*- coding: utf-8 -*-
def test():
    print u"árvíztűrő tükörfúrógép"
    assert False
```

```
Traceback (most recent call last):
  File "/usr/bin/nose2", line 9, in <module>
    load_entry_point('nose2==0.4.6', 'console_scripts', 'nose2')()
  File "/usr/lib/pymodules/python2.6/nose2/main.py", line 281, in discover
    return main(*args, **kwargs)
  File "/usr/lib/pymodules/python2.6/nose2/main.py", line 97, in __init__
    super(PluggableTestProgram, self).__init__(**kw)
  File "/usr/lib/pymodules/python2.6/unittest2/main.py", line 98, in __init__
    self.runTests()
  File "/usr/lib/pymodules/python2.6/nose2/main.py", line 257, in runTests
    self.result = runner.run(self.test)
  File "/usr/lib/pymodules/python2.6/nose2/runner.py", line 57, in run
    self.session.hooks.afterTestRun(event)
  File "/usr/lib/pymodules/python2.6/nose2/events.py", line 214, in __call__
    result = getattr(plugin, self.method)(event)
  File "/usr/lib/pymodules/python2.6/nose2/plugins/result.py", line 101, in afterTestRun
    self._reportSummary(event)
  File "/usr/lib/pymodules/python2.6/nose2/plugins/result.py", line 156, in _reportSummary
    self._printErrorList('FAIL', failures, evt.stream)
  File "/usr/lib/pymodules/python2.6/nose2/plugins/result.py", line 171, in _printErrorList
    stream.writeln("%s" % err)
  File "/usr/lib/pymodules/python2.6/nose2/util.py", line 281, in writeln
    self.stream.write(arg)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe1' in position 197: ordinal not in range(128)
```
