### PR TITLE
Simplify tox config and use Python 2.7+ by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,10 @@
 [tox]
-envlist=py26,py27,py32,py33,pypy,docs,self26,cov26
+envlist=py26,py27,py32,py33,pypy,docs,self27,cov27
+
+# Default settings for py27, py32, py33 and pypy
+[testenv]
+deps=-r{toxinidir}/requirements.txt
+commands=python -m unittest discover []
 
 [testenv:docs]
 basepython=python2.7
@@ -9,45 +14,24 @@ deps=-r{toxinidir}/requirements.txt
 commands=sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv:jython]
-basepython=jython
-
-[testenv:pypy]
-basepython=pypy
-
-[testenv]
 deps=-r{toxinidir}/requirements.txt
-     -r{toxinidir}/requirements-docs.txt
      -r{toxinidir}/requirements-py26.txt
 commands=unit2 discover []
 
-[testenv:py27]
+[testenv:py26]
 deps=-r{toxinidir}/requirements.txt
-     -r{toxinidir}/requirements-docs.txt
-commands=python -m unittest discover []
-
-[testenv:py32]
-deps=-r{toxinidir}/requirements.txt
-     -r{toxinidir}/requirements-docs.txt
-commands=python -m unittest discover []
-
-[testenv:py33]
-deps=-r{toxinidir}/requirements.txt
-     -r{toxinidir}/requirements-docs.txt
-commands=python -m unittest discover []
-
-[testenv:self26]
-deps=-r{toxinidir}/requirements.txt
-     -r{toxinidir}/requirements-docs.txt
      -r{toxinidir}/requirements-py26.txt
+commands=unit2 discover []
+
+[testenv:self27]
+deps=-r{toxinidir}/requirements.txt
 setenv=PYTHONPATH={toxinidir}
 commands=python -m nose2.__main__ []
 
-[testenv:cov26]
+[testenv:cov27]
 basepython=python2.6
 deps=coverage>=3.3
      -r{toxinidir}/requirements.txt
-     -r{toxinidir}/requirements-docs.txt
-     -r{toxinidir}/requirements-py26.txt
 commands=coverage erase
          coverage run -L {envbindir}/unit2 discover []
          coverage report --include=*nose2* --omit=*nose2/tests*


### PR DESCRIPTION
It shouldn't be necessary to require Sphinx and all of its dependencies just to run tests. I could be mistaken, but I didn't see any doctests in the documentation (wouldn't make sense, right?).
