### PR TITLE
Fix deprecation warnings for asserts in Python 3.2+

### DIFF
--- a/nose2/tests/unit/test_dundertest_plugin.py
+++ b/nose2/tests/unit/test_dundertest_plugin.py
@@ -22,11 +22,11 @@ class TestDunderTestPlugin(TestCase):
     def test_undefined_dunder_test_attribute_keeps_test(self):
         self.suite.addTest(self.caseClass('test_a'))
         self.plugin.removeNonTests(self.suite)
-        self.assertEquals(len(list(self.suite)), 1)
+        self.assertEqual(len(list(self.suite)), 1)
 
     def test_false_dunder_test_attribute_removes_test(self):
         dummyTest = self.caseClass('test_a')
         dummyTest.__test__ = False
         self.suite.addTest(dummyTest)
         self.plugin.removeNonTests(self.suite)
-        self.assertEquals(len(list(self.suite)), 0)
+        self.assertEqual(len(list(self.suite)), 0)

--- a/nose2/tests/unit/test_junitxml.py
+++ b/nose2/tests/unit/test_junitxml.py
@@ -63,7 +63,7 @@ class TestJunitXmlPlugin(TestCase):
         self.plugin.register()
 
         # unittest2 needs this
-        if not hasattr(self, 'assertRegexp'):
+        if not hasattr(self, 'assertRegex'):
             self.assertRegex = self.assertRegexpMatches
 
         class Test(unittest.TestCase):


### PR DESCRIPTION
Silence the deprecation warnings for py3k.
