### PR TITLE
Allow unverified/external argparse for Python 2.6 and pip 1.5+

### DIFF
--- a/requirements-py26.txt
+++ b/requirements-py26.txt
@@ -1,2 +1,4 @@
 unittest2==0.5.1
+--allow-external argparse
+--allow-unverified argparse
 argparse>=1.2.1


### PR DESCRIPTION
pip 1.5 contains a breaking change regarding the installation of external packages which affects the attempt to install argparse for Python 2.6 on Travis. First attempt at a patch.
