### PR TITLE
tox: set basepython to 2.7 for non-default environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,11 @@ envlist=py26,py27,py32,py33,pypy,docs,self27,cov27
 deps=-r{toxinidir}/requirements.txt
 commands=python -m unittest discover []
 
+[testenv:jython]
+deps=-r{toxinidir}/requirements.txt
+     -r{toxinidir}/requirements-py26.txt
+commands=unit2 discover []
+
 [testenv:docs]
 basepython=python2.7
 changedir=docs
@@ -13,26 +18,22 @@ deps=-r{toxinidir}/requirements.txt
      -r{toxinidir}/requirements-docs.txt
 commands=sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
-[testenv:jython]
-deps=-r{toxinidir}/requirements.txt
-     -r{toxinidir}/requirements-py26.txt
-commands=unit2 discover []
-
 [testenv:py26]
 deps=-r{toxinidir}/requirements.txt
      -r{toxinidir}/requirements-py26.txt
 commands=unit2 discover []
 
 [testenv:self27]
+basepython=python2.7
 deps=-r{toxinidir}/requirements.txt
 setenv=PYTHONPATH={toxinidir}
 commands=python -m nose2.__main__ []
 
 [testenv:cov27]
-basepython=python2.6
+basepython=python2.7
 deps=coverage>=3.3
      -r{toxinidir}/requirements.txt
 commands=coverage erase
-         coverage run -L {envbindir}/unit2 discover []
+         coverage run -m unittest discover []
          coverage report --include=*nose2* --omit=*nose2/tests*
          coverage html -d cover --include=*nose2* --omit=*nose2/tests*


### PR DESCRIPTION
Fixes for tox.ini to use correct version of Python. I've moved the environment definitions around a bit so that the intention is a lot clearer.
