### PR TITLE
Fix writing to the incorrect stream

### DIFF
--- a/nose2/plugins/result.py
+++ b/nose2/plugins/result.py
@@ -177,10 +177,10 @@ class ResultReporter(events.Plugin):
             stream.writeln("%s" % err)
 
     def _printSummary(self, reportEvent):
-        stream.writeln(self.separator2)
         self.session.hooks.beforeSummaryReport(reportEvent)
 
         stream = reportEvent.stream
+        stream.writeln(self.separator2)
         run = self.testsRun
         msg = (
             "Ran %d test%s in %.3fs\n" %


### PR DESCRIPTION
In several places, the documentation makes it clear that plugins should be able to control the output via one means or another.  In some cases, setting event.handled = True prevents default output.  Those cases seem to be working fine.

In other cases, you are told to wrap (or otherwise modify) the stream attached to the event to control output.  This mostly works, but I found three places in nose2 that were not writing to the correct stream (they were using the default stream instead of the stream on the event), which prevents a plugin from fully controlling the output.

This pull request simply fixes three `writeln` calls to get called on the event's stream, just as the rest of the function is already doing in each case.

In `_reportSummary()` I also moved the location of the `writeln` call down until after the event's stream had been set up.

This is important for my particular plugin, because the whole point of the plugin is to completely change the output.
