### PR TITLE
Windows port of bootstrap.sh

### DIFF
--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -1,0 +1,7 @@
+::
+:: NOTE: requires virtualenvwrapper-win
+::
+call mkvirtualenv nose2
+pip install -r requirements.txt
+pip install tox
+python setup.py develop


### PR DESCRIPTION
There's bootstrap.sh, but there's no its Windows counterpart (not everyone has cygwin after all).
I suggest it could be a good idea to also install `tox` right from the start.
