### PR TITLE
Docs build from tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,7 @@ include unittest.cfg
 include README.rst
 include license.txt
 recursive-include nose2/tests/functional/support *.py *.txt *.cfg
-recursive-include docs *.rst *.inc
+recursive-include docs *.inc *.py *.rst
 graft bin
 global-exclude __pycache__
 global-exclude *~


### PR DESCRIPTION
Fixes #119. 

For some reason `graft docs` was changed to explicit list of file extensions in 9ade7b47d5ce97580c1c7bdaaa1d5116650cce18. So I just added `docs/*.py` files to the tarball now.
