### PR TITLE
For Python2.6, downgrade argparse requirement from 1.2.1 to 1.1

### DIFF
--- a/requirements-py26.txt
+++ b/requirements-py26.txt
@@ -1,2 +1,2 @@
 unittest2==0.5.1
-argparse>=1.2.1
+argparse>=1.1

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ else:
 
     REQS = ['six>=1.1,<1.5']
     if sys.version_info < (2, 7):
-        REQS.extend(['unittest2>=0.5.1,<0.6', 'argparse>=1.2.1,<1.3'])
+        REQS.extend(['unittest2>=0.5.1,<0.6', 'argparse>=1.1,<1.3'])
 
     params['entry_points'] = {
         'console_scripts': [


### PR DESCRIPTION
Installing nose2 with pip for Python2.6 fails due to the `argparse>=1.2.1` dependency. This is because the argparse entry on PyPI is broken (version 1.2.1 is not actually available!). However, previous versions of argparse can be installed just fine, for example version 1.1.

I just tested changing `argparse>=1.2.1` to `argparse>=1.1` in both `requirements-py26.txt` and `setup.py`. After that, running `tox -e py26` successfully installed into a clean virtualenv and all of the tests passed. Furthermore, after committing and pushing just this change to my fork on github, `pip install git+https://github.com/taleinat/nose2.git#egg=nose2` worked like a charm. 

This fixes the issue which #157 also aims to fix, so choose just one of these fixes.
