### PR TITLE
Testclass unit tests

### DIFF
--- a/nose2/events.py
+++ b/nose2/events.py
@@ -886,8 +886,8 @@ class GetTestCaseNamesEvent(Event):
 
     .. attribute :: isTestMethod
 
-       Callable that plugins can use to examine test case attributes to determine
-       whether nose2 thinks they are test methods.
+       Callable that plugins can use to examine test case attributes to
+       determine whether nose2 thinks they are test methods.
 
     """
     _attrs = Event._attrs + ('loader', 'testCase', 'testMethodPrefix',

--- a/nose2/plugins/loader/testcases.py
+++ b/nose2/plugins/loader/testcases.py
@@ -64,9 +64,9 @@ class TestCaseLoader(events.Plugin):
             # name is a test case class
             event.extraTests.append(self._loadTestsFromTestCase(event, obj))
         elif (isinstance(parent, type) and
-              issubclass(parent, unittest.TestCase) and not
-              util.isgenerator(obj) and not
-              hasattr(obj, 'paramList')):
+              issubclass(parent, unittest.TestCase) and
+              not util.isgenerator(obj) and
+              not hasattr(obj, 'paramList')):
             # name is a single test method
             event.extraTests.append(parent(obj.__name__))
 
@@ -108,7 +108,8 @@ class TestCaseLoader(events.Plugin):
         if evt.extraNames:
             test_names.extend(evt.extraNames)
         sortkey = getattr(
-            testCaseClass, 'sortTestMethodsUsing', event.loader.sortTestMethodsUsing)
+            testCaseClass, 'sortTestMethodsUsing',
+            event.loader.sortTestMethodsUsing)
         if sortkey:
             test_names.sort(
                 key=sortkey)

--- a/nose2/plugins/loader/testclasses.py
+++ b/nose2/plugins/loader/testclasses.py
@@ -86,7 +86,7 @@ class TestClassLoader(events.Plugin):
     def registerInSubprocess(self, event):
         event.pluginClasses.append(self.__class__)
 
-    def pluginsLoaded(self, event):
+    def register(self):
         """Install extra hooks
 
         Adds the new plugin hooks:
@@ -95,6 +95,7 @@ class TestClassLoader(events.Plugin):
         - getTestMethodNames
 
         """
+        super(TestClassLoader, self).register()
         self.addMethods('loadTestsFromTestClass', 'getTestMethodNames')
 
     def loadTestsFromModule(self, event):
@@ -102,9 +103,9 @@ class TestClassLoader(events.Plugin):
         module = event.module
         for name in dir(module):
             obj = getattr(module, name)
-            if (isinstance(obj, type) and not
-                issubclass(obj, unittest.TestCase) and not
-                issubclass(obj, unittest.TestSuite) and
+            if (isinstance(obj, type) and
+                not issubclass(obj, unittest.TestCase) and
+                not issubclass(obj, unittest.TestSuite) and
                 name.lower().startswith(self.session.testMethodPrefix)):
                 event.extraTests.append(
                     self._loadTestsFromTestClass(event, obj))
@@ -125,9 +126,9 @@ class TestClassLoader(events.Plugin):
             # name is a test case class
             event.extraTests.append(self._loadTestsFromTestClass(event, obj))
         elif (isinstance(parent, type) and
-              not issubclass(parent, unittest.TestCase) and not
-              util.isgenerator(obj) and not
-              hasattr(obj, 'paramList')):
+              not issubclass(parent, unittest.TestCase) and
+              not util.isgenerator(obj) and
+              not hasattr(obj, 'paramList')):
             # name is a single test method
             event.extraTests.append(
                 util.transplant_class(

--- a/nose2/tests/unit/test_testclass_loader.py
+++ b/nose2/tests/unit/test_testclass_loader.py
@@ -1,4 +1,3 @@
-from nose2.compat import unittest
 from nose2.tests._common import TestCase
 from nose2.plugins.loader.testclasses import TestClassLoader
 from nose2 import events, loader, session
@@ -49,7 +48,6 @@ class TestTestClassLoader(TestCase):
         self.assertEqual(len(event.extraTests[1]._tests), 0)  # TestB
         self.assertEqual(len(event.extraTests[2]._tests), 0)  # TestC
 
-    @unittest.expectedFailure
     def test_get_testmethod_names_can_override_name_selection(self):
         class FooIsOnlyTest(events.Plugin):
 
@@ -66,7 +64,6 @@ class TestTestClassLoader(TestCase):
         self.assertEqual(len(event.extraTests[1]._tests), 0)  # TestB
         self.assertEqual(len(event.extraTests[2]._tests), 1)  # TestC
 
-    @unittest.expectedFailure
     def test_plugins_can_exclude_test_names(self):
         class Excluder(events.Plugin):
 


### PR DESCRIPTION
Added unit tests for TestClassLoader by porting existing unit tests for TestCaseLoader. Hopefully, this makes it safer to apply fixes to both loaders simultaneously.

Also moved registration of TestClassLoader's specific hooks to plugin.register in the process. This makes the two loaders more similar.
