### PR TITLE
Fix for silent plugin failures.

### DIFF
--- a/nose2/main.py
+++ b/nose2/main.py
@@ -259,7 +259,13 @@ class PluggableTestProgram(unittest.TestProgram):
         """Run tests"""
         # fire plugin hook
         runner = self._makeRunner()
-        self.result = runner.run(self.test)
+        try:
+            self.result = runner.run(self.test)
+        except Exception as e:
+            log.debug('Internal Error', exc_info=True)
+            sys.stderr.write('Internal Error: runTests aborted: %s\n'%(e))
+            if self.exit:
+                sys.exit(1)
         if self.exit:
             sys.exit(not self.result.wasSuccessful())
 

--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -96,6 +96,10 @@ class JUnitXmlReporter(events.Plugin):
             skipped.set('message', 'expected test failure')
             skipped.text = msg
 
+    def _check(self):
+        if not os.path.exists(os.path.dirname(self.path)):
+            raise IOError(2, 'JUnitXML: Parent folder does not exist for file', self.path)
+    
     def stopTestRun(self, event):
         """Output xml tree to file"""
         self.tree.set('name', 'nose2-junit')
@@ -106,6 +110,9 @@ class JUnitXmlReporter(events.Plugin):
         self.tree.set('time', "%.3f" % event.timeTaken)
 
         self._indent_tree(self.tree)
+        
+        self._check()
+        
         output = ET.ElementTree(self.tree)
         output.write(self.path, encoding="utf-8")
 

--- a/nose2/tests/_common.py
+++ b/nose2/tests/_common.py
@@ -173,6 +173,7 @@ class NotReallyAProc(object):
         self.args = args
         self.chdir = cwd
         self.kwargs = kwargs
+        self.result = None
 
     def __enter__(self):
         self._stdout = sys.__stdout__
@@ -198,7 +199,7 @@ class NotReallyAProc(object):
                     argv=('nose2',) + self.args, exit=False,
                     **self.kwargs)
             except SystemExit as e:
-                return "", "EXIT CODE %s" % str(e)
+                pass
             return self.stdout.getvalue(), self.stderr.getvalue()
 
     @property
@@ -206,6 +207,8 @@ class NotReallyAProc(object):
         return id(self)
 
     def poll(self):
+        if self.result is None:
+            return 1
         return not self.result.result.wasSuccessful()
 
 

--- a/nose2/tests/functional/support/scenario/junitxml/fail_to_write/test_junitxml_fail_to_write.py
+++ b/nose2/tests/functional/support/scenario/junitxml/fail_to_write/test_junitxml_fail_to_write.py
@@ -1,0 +1,7 @@
+import unittest
+
+
+class Test(unittest.TestCase):
+
+    def test(self):
+        pass

--- a/nose2/tests/functional/support/scenario/junitxml/fail_to_write/unittest.cfg
+++ b/nose2/tests/functional/support/scenario/junitxml/fail_to_write/unittest.cfg
@@ -1,0 +1,4 @@
+[junit-xml]
+always-on = False
+keep_restricted = False
+path = /does/not/exist.xml

--- a/nose2/tests/functional/test_junitxml_plugin.py
+++ b/nose2/tests/functional/test_junitxml_plugin.py
@@ -12,7 +12,8 @@ class JunitXmlPluginFunctionalTest(FunctionalTestCase, TestCase):
         work_dir = os.getcwd()
         test_dir = support_file(*scenario)
         junit_report = os.path.join(work_dir, 'nose2-junit.xml')
-
+        if os.path.exists(junit_report):
+            os.remove(junit_report)
         proc = self.runIn(work_dir,
                           '-s%s' % test_dir,
                           '--plugin=nose2.plugins.junitxml',
@@ -78,3 +79,20 @@ class JunitXmlPluginFunctionalTest(FunctionalTestCase, TestCase):
         self.assertTrue(os.path.isfile(junit_report),
                         "junitxml report wasn't found in working directory. "
                         "Searched for " + junit_report)
+
+
+class JunitXmlPluginFunctionalFailureTest(FunctionalTestCase, TestCase):
+    def test_failure_to_write_report(self):
+        proc = self.runIn('scenario/junitxml/fail_to_write',
+                          '--plugin=nose2.plugins.junitxml',
+                          '-v',
+                          '--junit-xml')
+        self.assertEqual(proc.poll(), 1)
+
+        self.assertTestRunOutputMatches(
+            proc,
+            stderr='test \(test_junitxml_fail_to_write.Test\) \.* ok')
+        self.assertTestRunOutputMatches(
+            proc, stderr=r'Internal Error: runTests aborted: \[Errno 2\] JUnitXML: Parent folder does not exist for file: \'/does/not/exist\.xml\'')
+
+


### PR DESCRIPTION
This change adds a junitxml functional test that tries to create a xml report in a folder that doesn't exist.
The IO error was not being propagated to the user, so I added a log.exception (that appears in the logging stream in stdout), and a more compact stderr message.

An important side-effect of this change is that now any plugin failure will not stop nose from continuing. I believe this is good as it prevents a bad plugin from breaking the test process, but this could be sometimes bad, in the case of an early failure that should really prevent anything else from happening... that said it looks like I haven't broken anything at this stage.

I'm happy to revisit the error messages, or maybe use log.debug('...', exc_info=True) to only display the stacktrace when -v is passed to nose, looking for feedback on this.

This fixes #159.
