### PR TITLE
Prototype for Layers plugin detection in Such

### DIFF
--- a/nose2/main.py
+++ b/nose2/main.py
@@ -68,6 +68,7 @@ class PluggableTestProgram(unittest.TestProgram):
 
     """
     sessionClass = session.Session
+    _currentSession = None
     loaderClass = loader.PluggableTestLoader
     runnerClass = runner.PluggableTestRunner
     defaultPlugins = ('nose2.plugins.loader.discovery',
@@ -86,7 +87,6 @@ class PluggableTestProgram(unittest.TestProgram):
                       'nose2.plugins.debugger',
                       )
     excludePlugins = ()
-
     # XXX override __init__ to warn that testLoader and testRunner are ignored?
     def __init__(self, **kw):
         plugins = kw.pop('plugins', [])
@@ -107,6 +107,8 @@ class PluggableTestProgram(unittest.TestProgram):
 
         """
         self.session = self.sessionClass()
+        self.__class__._currentSession = self.session
+        
         self.argparse = self.session.argparse  # for convenience
 
         # XXX force these? or can it be avoided?
@@ -270,6 +272,12 @@ class PluggableTestProgram(unittest.TestProgram):
         self.session.testRunner = event.runner
         return event.runner
 
+    @classmethod
+    def getCurrentSession(cls):
+        """Returns the current session or None if no `nose2.session.Session` is running.
+        
+        """
+        return cls._currentSession
 
 main = PluggableTestProgram
 

--- a/nose2/session.py
+++ b/nose2/session.py
@@ -72,7 +72,7 @@ class Session(object):
 
     """
     configClass = config.Config
-
+    
     def __init__(self):
         self.argparse = argparse.ArgumentParser(prog='nose2', add_help=False)
         self.pluginargs = self.argparse.add_argument_group(
@@ -209,3 +209,14 @@ class Session(object):
     @property
     def unittest(self):
         return self.get('unittest')
+
+    def isPluginLoaded(self, pluginName):
+        """Returns True if a given plugin is loaded.
+
+        :param pluginName: the name of the plugin module: e.g. "nose2.plugins.layers".
+
+        """
+        for plugin in self.plugins:
+            if pluginName == plugin.__class__.__module__:
+                return True
+        return False

--- a/nose2/tests/functional/support/such/test_such_without_layers.py
+++ b/nose2/tests/functional/support/such/test_such_without_layers.py
@@ -1,0 +1,27 @@
+from nose2.tools import such
+
+with such.A('system with complex setup') as it:
+
+    @it.has_setup
+    def setup():
+        it.things = [1]
+
+    @it.has_teardown
+    def teardown():
+        it.things = []
+
+    @it.should('do something')
+    def test():
+        assert it.things
+        it.assertEqual(len(it.things), 1)
+
+    with it.having('an expensive fixture'):
+        @it.has_setup
+        def setup():
+            it.things.append(2)
+
+        @it.should('do more things')
+        def test(case):
+            case.assertEqual(it.things[-1], 2)
+
+it.createTests(globals())

--- a/nose2/tests/functional/test_such_dsl.py
+++ b/nose2/tests/functional/test_such_dsl.py
@@ -1,5 +1,5 @@
 from nose2.tests._common import FunctionalTestCase
-
+from nose2.tools import such
 
 class TestSuchDSL(FunctionalTestCase):
     def test_runs_example(self):
@@ -69,3 +69,10 @@ class TestSuchDSL(FunctionalTestCase):
         self.assertTestRunOutputMatches(proc, stderr='OK')
         self.assertTestRunOutputMatches(proc, stderr='test 0000: should do bar:3')
         self.assertTestRunOutputMatches(proc, stderr='test 0001: should do bar and extra:3')
+
+    def test_such_without_layers_plugin(self):
+        proc = self.runIn('such',
+                          '-v',
+                          'test_such_without_layers')
+        self.assertTestRunOutputMatches(proc, stderr=r'FAILED')
+        self.assertTestRunOutputMatches(proc, stderr=such.LAYERS_PLUGIN_NOT_LOADED_MESSAGE)

--- a/nose2/tools/such.py
+++ b/nose2/tools/such.py
@@ -1,16 +1,19 @@
 from contextlib import contextmanager
 import inspect
 import logging
+import sys
 
 import six
 
 from nose2.compat import unittest
 from nose2 import util
+from nose2.main import PluggableTestProgram
 
 log = logging.getLogger(__name__)
 
 __unittest = True
 
+LAYERS_PLUGIN_NOT_LOADED_MESSAGE = 'Warning: Such will not function properly if the "nose2.plugins.layers" plugin not loaded!\n'
 
 @contextmanager
 def A(description):
@@ -213,7 +216,15 @@ class Scenario(object):
            it.createTests(globals())
 
         """
+        self._checkForLayersPlugin()
         self._makeGroupTest(mod, self._group)
+
+    def _checkForLayersPlugin(self):
+        currentSession = PluggableTestProgram.getCurrentSession()
+        if not currentSession:
+            return
+        if not currentSession.isPluginLoaded('nose2.plugins.layers'):
+            sys.stderr.write(LAYERS_PLUGIN_NOT_LOADED_MESSAGE)
 
     def _makeGroupTest(self, mod, group, parent_layer=None, position=0):
         layer = self._makeLayer(group, parent_layer, position)


### PR DESCRIPTION
This is a rough prototype that detects when Such is used without the layers plugin.
This PR is really just a proposal and a discussion point. I do believe that from a user point of view, nose2 should be able to warn the misled user. Another simple implementation would be to make the layers plugin part of the default list of plugins to load...
This fixes #201
