### PR TITLE
Only submit coveralls build for python 3.3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,5 @@ omit = nose2/*/tests/*
        nose2/tests/*
        test_*.*
        __init__.py
+       nose2/backports/*
+ 

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ build
 .*.sw[nop]
 .dir-locals.el
 six-*.egg
+.project
+.pydevproject
+.settings

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 script:
   - PYTHONPATH=. coverage run -m nose2.__main__ -v
 after_success:
-  - coveralls
+  - python -c "import sys; sys.exit(sys.version_info[0:2]!=(3,4));" && coveralls
 deploy:
   provider: pypi
   user: jpellerin

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py32,py33,py34,pypy,docs,self27,cov27
+envlist=py26,py27,py32,py33,py34,pypy,docs,self27,cov27,cov33
 
 # Default settings for py27, py32, py33, py34 and pypy
 [testenv]
@@ -33,7 +33,18 @@ commands=python -m nose2.__main__ []
 basepython=python2.7
 deps=coverage>=3.3
      -r{toxinidir}/requirements.txt
-commands=coverage erase
-         coverage run -m unittest discover []
-         coverage report --include=*nose2* --omit=*nose2/tests*
-         coverage html -d cover --include=*nose2* --omit=*nose2/tests*
+commands=python setup.py develop
+         coverage erase
+         coverage run -m nose2.__main__ nose2
+         coverage report --include=*nose2* --omit=*nose2/tests* --omit=*nose2/backports*
+         coverage html -d cover/cov27 --include=*nose2* --omit=*nose2/tests* --omit=*nose2/backports*
+
+[testenv:cov34]
+basepython=python3.4
+deps=coverage>=3.3
+     -r{toxinidir}/requirements.txt
+commands=python setup.py develop
+         coverage erase
+         coverage run -m nose2.__main__ nose2
+         coverage report --include=*nose2* --omit=*nose2/tests* --omit=*nose2/backports*
+         coverage html -d cover/cov34 --include=*nose2* --omit=*nose2/tests* --omit=*nose2/backports*


### PR DESCRIPTION
This is a proposal to submit coverage info to coveralls for a single python interpreter (I arbitrarily chose 3.3).
The average coverage value is slightly smaller this way, but at least you can track progress on coverage without receiving emails saying "coverage decreased (-2.36%)" every second commit...

That said, coverage reporting on nose2 has still issues on both travis and tox:
- Tox: when running "tox -e cov27" I get a very low coverage compared to the coveralls value (53%), and for example the nose2.plugins.loader.testclasses is reportedly only covered 35%, which is incorrect...
- Travis: even with this PR and coveralls only run on py33, I had random variations in coverage, see these 2 builds with no code change in-between: https://coveralls.io/builds/871995 and https://coveralls.io/builds/872041. And for these two builds, nose2.plugins.loader.testclasses has either 0% coverage (build 871995) or 89% (build 872041).

I'll keep looking into these...
