### PR TITLE
Bump up six version in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ except ImportError:
     from distutils.core import setup
 else:
 
-    REQS = ['six>=1.1,<1.5']
+    REQS = ['six>=1.1']
     if sys.version_info < (2, 7):
         REQS.extend(['unittest2>=0.5.1,<0.6', 'argparse>=1.2.1,<1.3'])
 


### PR DESCRIPTION
Not sure if this is intentional, but currently it gives me an error as follows when I install nose2 as editable and run my tests. This bumps up six version in setup.py to match with the version in requirements.txt.

```
Traceback (most recent call last):
  File "/Users/starsirius/Code/project/venv/bin/nose2", line 5, in <module>
    from pkg_resources import require
  File "/Users/starsirius/Code/project/venv/lib/python2.7/site-packages/pkg_resources.py", line 2720, in <module>
    parse_requirements(__requires__), Environment()
  File "/Users/starsirius/Code/project/venv/lib/python2.7/site-packages/pkg_resources.py", line 588, in resolve
    raise DistributionNotFound(req)
pkg_resources.DistributionNotFound: six>=1.1,<1.5
make: *** [test] Error 1
```

Re: https://github.com/nose-devs/nose2/blob/7e48591d46986c4d79bf01f378aec7cbb599bb90/requirements.txt#L1
