### PR TITLE
add missing requirements-pypy3.txt

### DIFF
--- a/requirements-pypy3.txt
+++ b/requirements-pypy3.txt
@@ -1,0 +1,1 @@
+-r requirements.txt


### PR DESCRIPTION
After ce7b8dbf42de27eddd6e76b096c57d7f1abe845c all travis-ci jobs are
failing the pypy3 tests with `Could not open requirements file: [Errno 2] No such file or directory: 'requirements-pypy3.txt'`
