### PR TITLE
Tests in JunitXmlPluginFunctionalFailureTest fail on Windows

### DIFF
--- a/nose2/tests/functional/test_junitxml_plugin.py
+++ b/nose2/tests/functional/test_junitxml_plugin.py
@@ -119,8 +119,13 @@ class JunitXmlPluginFunctionalFailureTest(FunctionalTestCase, TestCase):
         self.assertTestRunOutputMatches(
             proc,
             stderr='test \(test_junitxml_fail_to_write.Test\) \.* ok')
+
+        filename_for_regex = os.path.abspath('/does/not/exist.xml')
+        filename_for_regex = filename_for_regex.replace('\\', r'\\\\')
         self.assertTestRunOutputMatches(
-            proc, stderr=r'Internal Error: runTests aborted: \[Errno 2\] JUnitXML: Parent folder does not exist for file: \'/does/not/exist\.xml\'')
+            proc, stderr="Internal Error: runTests aborted: \[Errno 2\] "
+                         "JUnitXML: Parent folder does not exist for file: "
+                         "\'%s'" % filename_for_regex)
 
     def test_failure_to_read_missing_properties(self):
         proc = self.runIn('scenario/junitxml/missing_properties',
@@ -132,8 +137,14 @@ class JunitXmlPluginFunctionalFailureTest(FunctionalTestCase, TestCase):
         self.assertTestRunOutputMatches(
             proc,
             stderr='test \(test_junitxml_missing_properties.Test\) \.* ok')
+
+        filename_for_regex = os.path.join('missing_properties',
+                                          'properties.json')
+        filename_for_regex = filename_for_regex.replace('\\', r'\\\\')
         self.assertTestRunOutputMatches(
-            proc, stderr=r'Internal Error: runTests aborted: \[Errno 2\] JUnitXML: Properties file does not exist: \'.*/missing_properties/properties\.json\'')
+            proc, stderr="Internal Error: runTests aborted: \[Errno 2\] "
+                         "JUnitXML: Properties file does not exist: "
+                         "'.*%s'" % filename_for_regex)
 
 
     def test_failure_to_read_empty_properties(self):
@@ -146,5 +157,11 @@ class JunitXmlPluginFunctionalFailureTest(FunctionalTestCase, TestCase):
         self.assertTestRunOutputMatches(
             proc,
             stderr='test \(test_junitxml_empty_properties.Test\) \.* ok')
+
+        filename_for_regex = os.path.join('empty_properties',
+                                          'properties.json')
+        filename_for_regex = filename_for_regex.replace('\\', r'\\')
         self.assertTestRunOutputMatches(
-            proc, stderr=r'Internal Error: runTests aborted: JUnitXML: could not decode file: \'.*/empty_properties/properties\.json\'')
+            proc, stderr="Internal Error: runTests aborted: "
+                         "JUnitXML: could not decode file: "
+                         "'.*%s'" % filename_for_regex)


### PR DESCRIPTION
Execute functional tests in `test_junitxml_plugin.py:JunitXmlPluginFunctionalFailureTest` on Windows. Tests fail (Windows uses different line separator):

```
D:\src\nose2\nose2\tests\functional>nosetests --nologcapture test_junitxml_plugin.py:JunitXmlPluginFunctionalFailureTest
FFF
======================================================================
FAIL: test_failure_to_read_empty_properties (nose2.tests.functional.test_junitxml_plugin.JunitXmlPluginFunctionalFailureTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\src\nose2\nose2\tests\functional\test_junitxml_plugin.py", line 150, in test_failure_to_read_empty_properties
    proc, stderr=r'Internal Error: runTests aborted: JUnitXML: could not decode file: \'.*/empty_properties/properties\.json\'')
  File "D:\src\nose2\nose2\tests\_common.py", line 64, in assertTestRunOutputMatches
    testf(util.safe_decode(cmd_stderr), stderr)
AssertionError: Regexp didn't match: "Internal Error: runTests aborted: JUnitXML: could not decode file: \\'.*/empty_properties/properties\\.json\\'" not found in u"test (test_junitxml_
empty_properties.Test) ... ok\nInternal Error: runTests aborted: JUnitXML: could not decode file: 'D:\\src\\nose2\\nose2\\tests\\functional\\support\\scenario\\junitxml\\empty_propertie
s\\properties.json'\n"

======================================================================
FAIL: test_failure_to_read_missing_properties (nose2.tests.functional.test_junitxml_plugin.JunitXmlPluginFunctionalFailureTest)
----------------------------------------------------------------------
...
======================================================================
FAIL: test_failure_to_write_report (nose2.tests.functional.test_junitxml_plugin.JunitXmlPluginFunctionalFailureTest)
----------------------------------------------------------------------
...
----------------------------------------------------------------------
Ran 3 tests in 0.102s

FAILED (failures=3)

```
