### PR TITLE
Sphinx build fails

### DIFF
--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -39,7 +39,8 @@ class JUnitXmlReporter(events.Plugin):
             self.config.as_str('path', default='nose2-junit.xml'))
         self.keep_restricted = self.config.as_bool('keep_restricted',
                                                    default=False)
-        self.test_properties = self.config.as_str('test_properties')
+        self.test_properties = self.config.as_str('test_properties',
+                                                  default=None)
         if self.test_properties is not None:
             self.test_properties_path = os.path.realpath(self.test_properties)
         self.errors = 0


### PR DESCRIPTION
After merge of 64b78ff627b45870c623c1a8344fbdfb30a3b747, sphinx build fails:
```
(nose2) D:\src\nose2>tox -c tox-win32.ini -e docs
...
Traceback (most recent call last):
...
  File "D:\src\nose2\nose2\sphinxext.py", line 66, in document
    obj = plugin(session=ssn)
  File "D:\src\nose2\nose2\events.py", line 42, in __call__
    instance.__init__(*args, **kwargs)
  File "D:\src\nose2\nose2\plugins\junitxml.py", line 44, in __init__
    self.test_properties_path = os.path.realpath(self.test_properties)
  File "D:\src\nose2\.tox\docs\lib\ntpath.py", line 471, in abspath
    path = _getfullpathname(path)
TypeError: coercing to Unicode: need string or buffer, object found
```