### PR TITLE
Fixed setuptools to work with Layers

### DIFF
--- a/nose2/collector.py
+++ b/nose2/collector.py
@@ -13,11 +13,16 @@ def collector():
             ok = self._collector(result_)
             sys.exit(not ok)
 
-        def _collector(self, result_):
+        def _get_objects(self):
             ssn = session.Session()
             ldr = loader.PluggableTestLoader(ssn)
             rnr = runner.PluggableTestRunner(ssn)
+            return ssn, ldr, rnr
 
+        def _collector(self, result_):
+            ssn, ldr, rnr = self._get_objects()
+
+            ssn.testLoader = ldr
             ssn.loadConfigFiles('unittest.cfg', 'nose2.cfg', 'setup.cfg')
             ssn.setStartDir()
             ssn.prepareSysPath()

--- a/nose2/tests/unit/test_collector.py
+++ b/nose2/tests/unit/test_collector.py
@@ -1,3 +1,9 @@
+try:
+    from unittest import mock
+except ImportError:
+    # Older python versions dont have mock by default
+    import mock
+
 from nose2.tests._common import TestCase, RedirectStdStreams
 from nose2 import collector
 from textwrap import dedent
@@ -20,3 +26,18 @@ class TestCollector(TestCase):
         self.assertEqual("", redir.stdout.getvalue())
         self.assertTrue(re.match(r'\n-+\nRan 0 tests in \d.\d\d\ds\n\nOK\n',
                                  redir.stderr.getvalue()))
+
+    def test_collector_sets_testLoader_in_session(self):
+        """
+        session.testLoader needs to be set so that plugins that use this
+        field (like Layers) dont break.
+        """
+        test = collector.collector()
+        mock_session = mock.MagicMock()
+        mock_loader = mock.MagicMock()
+        mock_runner = mock.MagicMock()
+        test._get_objects = mock.Mock(return_value=(mock_session,
+                                                    mock_loader,
+                                                    mock_runner))
+        test._collector(None)
+        self.assertTrue(mock_session.testLoader is mock_loader)

--- a/requirements-2.7.txt
+++ b/requirements-2.7.txt
@@ -1,1 +1,2 @@
+mock
 -r requirements.txt

--- a/requirements-py26.txt
+++ b/requirements-py26.txt
@@ -1,3 +1,4 @@
+mock
 unittest2==0.5.1
 --allow-external argparse
 --allow-unverified argparse


### PR DESCRIPTION
Fixes #233 

I had to add mock to the requirements for older python versions, and do a small refactoring to the collector as that was the way I could write a test for this issue. 

Tested on python 3.4 and 2.7