### PR TITLE
add missing Makefile for docs in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,7 @@ include unittest.cfg
 include README.rst
 include license.txt
 recursive-include nose2/tests/functional/support *.py *.txt *.cfg
-recursive-include docs *.inc *.py *.rst
+recursive-include docs *.inc *.py *.rst Makefile
 graft bin
 global-exclude __pycache__
 global-exclude *~


### PR DESCRIPTION
When packaging docs as part of the Gentoo ebuild I found the Makefile
for documentation wasn't included in the sdist.  This simple patch
ensures that it's included.