### PR TITLE
Tweak docstrings under `nose2/`

### DIFF
--- a/nose2/compat.py
+++ b/nose2/compat.py
@@ -1,7 +1,7 @@
 """unittest/unittest2 compatibility wrapper.
 
-Anything internal to nose2 *must* import unittest from here, to be
-sure that it is using unittest2 when on older pythons.
+Anything internal to nose2 *must* import unittest from here to be
+certain that it is using unittest2 when run on older Python versions.
 
 Yes::
 
@@ -26,7 +26,7 @@ try:
     unittest.installHandler
 except AttributeError:
     raise ImportError(
-        "Built-in unittest version too old, unittest2 is required")
+        "Built-in unittest version too old; unittest2 is required")
 
 __unittest = True
 

--- a/nose2/config.py
+++ b/nose2/config.py
@@ -24,8 +24,8 @@ class Config(object):
     def as_bool(self, key, default=None):
         """Get key value as boolean
 
-        1, t, true, on, yes and y (case insensitive) are accepted as True
-        values. All other values are False.
+        1, t, true, on, yes and y (case insensitive) are accepted as ``True``
+        values. All other values are ``False``.
 
         """
         try:

--- a/nose2/events.py
+++ b/nose2/events.py
@@ -69,7 +69,7 @@ class Plugin(six.with_metaclass(PluginMeta)):
     .. attribute :: commandLineSwitch
 
        A tuple of (short opt, long opt, help text) that defines a command
-       line flag that activates this plugin. The short opt may be None. If
+       line flag that activates this plugin. The short opt may be ``None``. If
        defined, it must be a single upper-case character. Both short and
        long opt must *not* start with dashes.
 
@@ -84,7 +84,7 @@ class Plugin(six.with_metaclass(PluginMeta)):
     .. attribute :: alwaysOn
 
        If this plugin should automatically register itself, set alwaysOn to
-       True. Default is False.
+       ``True``. Default is ``False``.
 
     .. note ::
 
@@ -312,7 +312,7 @@ class Event(object):
 
     .. attribute :: handled
 
-       Set to True to indicate that a plugin has handled the event,
+       Set to ``True`` to indicate that a plugin has handled the event,
        and no other plugins or core systems should process it further.
 
     .. attribute :: version
@@ -442,7 +442,7 @@ class StartTestRunEvent(Event):
              ...
 
     To prevent normal test execution, plugins may set ``handled`` on
-    this event to True. When ``handled`` is true, the test executor
+    this event to ``True``. When ``handled`` is true, the test executor
     does not run at all.
 
     """
@@ -562,19 +562,19 @@ class TestOutcomeEvent(Event):
 
        If the test resulted in an exception, the tuple of (exception
        class, exception value, traceback) as returned by
-       sys.exc_info(). If the test did not result in an exception,
-       None.
+       ``sys.exc_info()``. If the test did not result in an exception,
+       ``None``.
 
     .. attribute :: reason
 
-       For test outcomes that include a reason (Skips, for example),
+       For test outcomes that include a reason (``Skips``, for example),
        the reason.
 
     .. attribute :: expected
 
        Boolean indicating whether the test outcome was expected. In
        general, all tests are expected to pass, and any other outcome
-       will have expected as False. The exceptions to that rule are
+       will have expected as ``False``. The exceptions to that rule are
        unexpected successes and expected failures.
 
     .. attribute :: shortLabel
@@ -629,7 +629,7 @@ class LoadFromModuleEvent(Event):
 
     Plugins may set ``handled`` on this event and return a test suite
     to prevent other plugins from loading tests from the module. If
-    any plugin sets ``handled`` to True, ``extraTests`` will be
+    any plugin sets ``handled`` to ``True``, ``extraTests`` will be
     ignored.
 
     """
@@ -672,7 +672,7 @@ class LoadFromTestCaseEvent(Event):
 
     Plugins may set ``handled`` on this event and return a test suite
     to prevent other plugins from loading tests from the test case. If
-    any plugin sets ``handled`` to True, ``extraTests`` will be
+    any plugin sets ``handled`` to ``True``, ``extraTests`` will be
     ignored.
 
     """
@@ -695,11 +695,11 @@ class LoadFromNamesEvent(Event):
 
     .. attribute :: names
 
-       List of test names. May be empty or None.
+       List of test names. May be empty or ``None``.
 
     .. attribute :: module
 
-       Module to load from. May be None. If not None, names should be
+       Module to load from. May be ``None``. If not ``None``, names should be
        considered relative to this module.
 
     .. attribute :: extraTests
@@ -710,7 +710,7 @@ class LoadFromNamesEvent(Event):
 
     Plugins may set ``handled`` on this event and return a test suite
     to prevent other plugins from loading tests from the test names. If
-    any plugin sets ``handled`` to True, ``extraTests`` will be
+    any plugin sets ``handled`` to ``True``, ``extraTests`` will be
     ignored.
 
     """
@@ -741,7 +741,7 @@ class LoadFromNameEvent(Event):
 
     .. attribute :: module
 
-       Module to load from. May be None. If not None, names should be
+       Module to load from. May be ``None``. If not ``None``, names should be
        considered relative to this module.
 
     .. attribute :: extraTests
@@ -752,7 +752,7 @@ class LoadFromNameEvent(Event):
 
     Plugins may set ``handled`` on this event and return a test suite
     to prevent other plugins from loading tests from the test name. If
-    any plugin sets ``handled`` to True, ``extraTests`` will be
+    any plugin sets ``handled`` to ``True``, ``extraTests`` will be
     ignored.
 
     """
@@ -804,7 +804,7 @@ class HandleFileEvent(Event):
 
     Plugins may set ``handled`` on this event and return a test suite
     to prevent other plugins from loading tests from the file. If
-    any plugin sets ``handled`` to True, ``extraTests`` will be
+    any plugin sets ``handled`` to ``True``, ``extraTests`` will be
     ignored.
 
     """
@@ -826,7 +826,7 @@ class MatchPathEvent(Event):
 
     """Event fired during file matching.
 
-    Plugins may return False and set ``handled`` on this event to prevent
+    Plugins may return ``False`` and set ``handled`` on this event to prevent
     a file from being matched as a test file, regardless of other system
     settings.
 
@@ -871,7 +871,7 @@ class GetTestCaseNamesEvent(Event):
     .. attribute :: testMethodPrefix
 
        Set this to change the test method prefix. Unless set by a plugin,
-       it is None.
+       it is ``None``.
 
     .. attribute :: extraNames
 
@@ -917,9 +917,9 @@ class ResultSuccessEvent(Event):
 
     .. attribute :: success
 
-       Set this to True to indicate that the test run was
+       Set this to ``True`` to indicate that the test run was
        successful. If no plugin sets the ``success`` to
-       True, the test run fails.
+       ``True``, the test run fails.
 
     """
     _attrs = Event._attrs + ('result', 'success')
@@ -943,7 +943,7 @@ class ResultStopEvent(Event):
 
     .. attribute :: shouldStop
 
-       Set to True to indicate that the test run should stop.
+       Set to ``True`` to indicate that the test run should stop.
 
     """
     _attrs = Event._attrs + ('result', 'shouldStop')
@@ -1069,7 +1069,7 @@ class UserInteractionEvent(Event):
     Plugins that capture stdout or otherwise prevent user interaction
     should respond to this event.
 
-    To prevent the user interaction from occurring, return False and
+    To prevent the user interaction from occurring, return ``False`` and
     set ``handled``. Otherwise, turn off whatever you are doing that
     prevents users from typing/clicking/touching/psionics/whatever.
 
@@ -1117,11 +1117,11 @@ class CreateTestsEvent(Event):
 
     .. attribute :: names
 
-       List of test names. May be empty or None.
+       List of test names. May be empty or ``None``.
 
     .. attribute :: module
 
-       Module to load from. May be None. If not None, names should be
+       Module to load from. May be ``None``. If not ``None``, names should be
        considered relative to this module.
 
     """

--- a/nose2/exceptions.py
+++ b/nose2/exceptions.py
@@ -7,4 +7,4 @@ __unittest = True
 
 class TestNotFoundError(Exception):
 
-    """Exception raised when a named test cannot be found"""
+    """Raised when a named test cannot be found"""

--- a/nose2/loader.py
+++ b/nose2/loader.py
@@ -104,7 +104,7 @@ class PluggableTestLoader(object):
         return name.lower()
 
     def discover(self, start_dir=None, pattern=None):
-        """Compatibility shim for load_tests protocol."""
+        """Compatibility shim for ``load_tests`` protocol."""
         try:
             oldsd = self.session.startDir
             self.session.startDir = start_dir

--- a/nose2/main.py
+++ b/nose2/main.py
@@ -18,9 +18,9 @@ class PluggableTestProgram(unittest.TestProgram):
     but most of them are ignored as their functions are
     handled by plugins.
 
-    :param module: Module in which to run tests. Default: __main__
-    :param defaultTest: Default test name. Default: None
-    :param argv: Command line args. Default: sys.argv
+    :param module: Module in which to run tests. Default: :func:`__main__`
+    :param defaultTest: Default test name. Default: ``None``
+    :param argv: Command line args. Default: ``sys.argv``
     :param testRunner: *IGNORED*
     :param testLoader: *IGNORED*
     :param exit: Exit after running tests?
@@ -49,7 +49,7 @@ class PluggableTestProgram(unittest.TestProgram):
 
           Overriding this attribute is the only way to customize
           the test loader class. Passing a test loader to
-          ``__init__`` does not work.
+          :class:`__init__` does not work.
 
     .. attribute :: runnerClass
 
@@ -60,7 +60,7 @@ class PluggableTestProgram(unittest.TestProgram):
 
           Overriding this attribute is the only way to customize
           the test runner class. Passing a test runner to
-          ``__init__`` does not work.
+          :func:`__init__` does not work.
 
     .. attribute :: defaultPlugins
 
@@ -103,7 +103,7 @@ class PluggableTestProgram(unittest.TestProgram):
         """Parse command line args
 
         Parses arguments and creates a configuration session,
-        then calls createTests.
+        then calls :func:`createTests`.
 
         """
         self.session = self.sessionClass()
@@ -230,7 +230,7 @@ class PluggableTestProgram(unittest.TestProgram):
         """Load available plugins
 
 
-        ``self.defaultPlugins`` and ``self.excludePlugins`` are passed
+        :func:`self.defaultPlugins`` and :func:`self.excludePlugins` are passed
         to the session to alter the list of plugins that will be
         loaded.
 
@@ -280,7 +280,7 @@ class PluggableTestProgram(unittest.TestProgram):
 
     @classmethod
     def getCurrentSession(cls):
-        """Returns the current session or None if no `nose2.session.Session` is running.
+        """Returns the current session, or ``None`` if no :class:`nose2.session.Session` is running.
         
         """
         return cls._currentSession

--- a/nose2/main.py
+++ b/nose2/main.py
@@ -49,7 +49,7 @@ class PluggableTestProgram(unittest.TestProgram):
 
           Overriding this attribute is the only way to customize
           the test loader class. Passing a test loader to
-          :class:`__init__` does not work.
+          :func:`__init__` does not work.
 
     .. attribute :: runnerClass
 

--- a/nose2/plugins/attrib.py
+++ b/nose2/plugins/attrib.py
@@ -20,7 +20,7 @@ class AttributeSelector(Plugin):
         self.addArgument(
             self.eval_attribs, "E", "eval-attribute",
             "Select tests for whose attributes the "
-            "given Python expression evalures to True")
+            "given Python expression evaluates to ``True``")
 
     def handleArgs(self, args):
         """Register if any attribs defined"""

--- a/nose2/plugins/collect.py
+++ b/nose2/plugins/collect.py
@@ -17,7 +17,7 @@ class CollectOnly(Plugin):
 
     configSection = 'collect-only'
     commandLineSwitch = (None, 'collect-only',
-                         'Collect and output test names, do not run any tests')
+                         'Collect and output test names; do not run any tests')
     _mpmode = False
 
     def registerInSubprocess(self, event):
@@ -25,7 +25,7 @@ class CollectOnly(Plugin):
         self._mpmode = True
 
     def startTestRun(self, event):
-        """Replace event.executeTests"""
+        """Replace ``event.executeTests``"""
         if self._mpmode:
             return
         event.executeTests = self.collectTests
@@ -34,7 +34,7 @@ class CollectOnly(Plugin):
         event.executeTests = self.collectTests
 
     def collectTests(self, suite, result):
-        """Collect tests but don't run them"""
+        """Collect tests, but don't run them"""
         for test in suite:
             if isinstance(test, unittest.TestSuite):
                 self.collectTests(test, result)

--- a/nose2/plugins/debugger.py
+++ b/nose2/plugins/debugger.py
@@ -6,7 +6,7 @@ whenever it sees a test outcome that includes exc_info.
 
 It fires :func:`beforeInteraction` before launching pdb and
 :func:`afterInteraction` after. Other plugins may implement
-:func:`beforeInteraction` to return False and set event.handled to
+:func:`beforeInteraction` to return ``False`` and set ``event.handled`` to
 prevent this plugin from launching pdb.
 
 """

--- a/nose2/plugins/dundertest.py
+++ b/nose2/plugins/dundertest.py
@@ -1,6 +1,6 @@
 """
 This plugin implements :func:`startTestRun`, which excludes all test objects
-that define a ``__test__`` attribute with a truth value of False.
+that define a ``__test__`` attribute that evaluates to ``False``.
 """
 from unittest import TestSuite
 from nose2 import events
@@ -10,15 +10,14 @@ __unittest = True
 
 class DunderTestFilter(events.Plugin):
     """
-    Exclude all tests defining a ``__test__`` attribute with a truth value of
-    False.
+    Exclude all tests defining a ``__test__`` attribute that evaluates to ``False``.
     """
     alwaysOn = True
 
     def startTestRun(self, event):
         """
         Recurse :attr:`event.suite` and remove all test suites and test cases
-        that define a ``__test__`` attribute with a truth value of False.
+        that define a ``__test__`` attribute that evaluates to ``False``.
         """
         self.removeNonTests(event.suite)
 

--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -4,13 +4,15 @@ Output test reports in junit-xml format.
 This plugin implements :func:`startTest`, :func:`testOutcome` and
 :func:`stopTestRun` to compile and then output a test report in
 junit-xml format. By default, the report is written to a file called
-``nose2-junit.xml`` in the current working directory. You can
-configure the output filename by setting ``path`` in a ``[junit-xml]``
+``nose2-junit.xml`` in the current working directory. 
+
+You can configure the output filename by setting ``path`` in a ``[junit-xml]``
 section in a config file.  Unicode characters which are invalid in XML 1.0
-are replaced with the U+FFFD replacement character.  In the case that your
-software throws an error with an invalid byte string.  By default, the
-ranges of discouraged characters are replaced as well.  This can be
-changed by setting the keep_restricted configuration variable to True.
+are replaced with the ``U+FFFD`` replacement character.  In the case that your
+software throws an error with an invalid byte string.  
+
+By default, the ranges of discouraged characters are replaced as well.  This can be
+changed by setting the ``keep_restricted`` configuration variable to ``True``.
 
 """
 # Based on unittest2/plugins/junitxml.py,

--- a/nose2/plugins/loader/discovery.py
+++ b/nose2/plugins/loader/discovery.py
@@ -3,11 +3,11 @@ Discovery-based test loader.
 
 This plugin implements nose2's automatic test module discovery. It
 looks for test modules in packages and directories whose names start
-with 'test', then fires the :func:`loadTestsFromModule` hook for each
+with ``test``, then fires the :func:`loadTestsFromModule` hook for each
 one to allow other plugins to load the actual tests.
 
 It also fires :func:`handleFile` for every file that it sees, and
-:func:`matchPath` for every python module, to allow other plugins to
+:func:`matchPath` for every Python module, to allow other plugins to
 load tests from other kinds of files and to influence which modules
 are examined for tests.
 

--- a/nose2/plugins/loader/eggdiscovery.py
+++ b/nose2/plugins/loader/eggdiscovery.py
@@ -3,11 +3,11 @@ Egg-based discovery test loader.
 
 This plugin implements nose2's automatic test module discovery inside Egg Files.
 It looks for test modules in packages whose names start
-with 'test', then fires the :func:`loadTestsFromModule` hook for each
+with ``test``, then fires the :func:`loadTestsFromModule` hook for each
 one to allow other plugins to load the actual tests.
 
 It also fires :func:`handleFile` for every file that it sees, and
-:func:`matchPath` for every python module, to allow other plugins to
+:func:`matchPath` for every Python module, to allow other plugins to
 load tests from other kinds of files and to influence which modules
 are examined for tests.
 

--- a/nose2/plugins/loader/generators.py
+++ b/nose2/plugins/loader/generators.py
@@ -15,7 +15,7 @@ tuple, or the arguments may be grouped into a separate tuple::
       yield check, (1, 2)
 
 To address a particular generated test via a command-line test name,
-append a colon (':') followed by the index, *starting from 1*, of the
+append a colon (':') followed by the index (*starting from 1*) of the
 generated case you want to execute.
 
 """

--- a/nose2/plugins/loader/loadtests.py
+++ b/nose2/plugins/loader/loadtests.py
@@ -1,15 +1,15 @@
 """
-Loader that implements the load_tests protocol.
+Loader that implements the ``load_tests`` protocol.
 
-This plugin implements the load_tests protocol as detailed in the
-documentation for unittest2.
+This plugin implements the ``load_tests`` protocol as detailed in the
+documentation for :mod:`unittest2`.
 
 See the `load_tests protocol`_ documentation for more information.
 
 .. warning ::
 
-   Test suites using the load_tests protocol do not work correctly
-   with the multiprocess plugin as of nose2 04. This will be
+   Test suites using the ``load_tests`` protocol do not work correctly
+   with the :mod:`multiprocess` plugin as of nose2 04. This will be
    fixed in a future release.
 
 .. _load_tests protocol: http://docs.python.org/library/unittest.html#load-tests-protocol
@@ -34,7 +34,7 @@ class LoadTestsLoader(events.Plugin):
         event.pluginClasses.append(self.__class__)
 
     def moduleLoadedSuite(self, event):
-        """Run load_tests in a module.
+        """Run ``load_tests`` in a module.
 
         May add to or filter tests loaded in module.
 
@@ -55,10 +55,10 @@ class LoadTestsLoader(events.Plugin):
             return suite
 
     def handleDir(self, event):
-        """Run load_tests in packages.
+        """Run ``load_tests`` in packages.
 
         If a package itself matches the test file pattern, run
-        load_tests in its __init__.py, and stop default test
+        ``load_tests`` in its :file:`__init__.py`, and stop default test
         discovery for that package.
 
         """

--- a/nose2/plugins/loader/parameters.py
+++ b/nose2/plugins/loader/parameters.py
@@ -8,7 +8,7 @@ loading tests from parameterized test functions and methods.
 To parameterize a function or test case method, use :func:`nose2.tools.params`.
 
 To address a particular parameterized test via a command-line test name,
-append a colon (':') followed by the index, *starting from 1*, of the
+append a colon (':') followed by the index (*starting from 1*) of the
 case you want to execute.
 
 Such And The Parameters Plugin

--- a/nose2/plugins/loader/testclasses.py
+++ b/nose2/plugins/loader/testclasses.py
@@ -23,10 +23,10 @@ test loaders to use:
 
    Plugins can use this hook to load tests from a class that is not a
    :class:`unittest.TestCase` subclass. To prevent other plugins from
-   loading tests from the test class, set ``event.handled`` to True and
+   loading tests from the test class, set ``event.handled`` to ``True`` and
    return a test suite. Plugins can also append tests to
-   ``event.extraTests`` -- ususally that's what you want to do, since
-   that will allow other plugins to load their tests from the test
+   ``event.extraTests``. Ususally, that's what you want, since
+   it allows other plugins to load their tests from the test
    case as well.
 
 .. function :: getTestMethodNames(self, event)
@@ -38,7 +38,7 @@ test loaders to use:
    :class:`unittest.TestCase` subclass by the standard nose2 test
    loader plugins (and other plugins that respect the results of the
    hook). To force a specific list of names, set ``event.handled`` to
-   True and return a list: this exact list will be the only test case
+   ``True`` and return a list: this exact list will be the only test case
    names loaded from the test case. Plugins can also extend the list
    of names by appending test names to ``event.extraNames``, and
    exclude names by appending test names to ``event.excludedNames``.

--- a/nose2/plugins/mp.py
+++ b/nose2/plugins/mp.py
@@ -120,13 +120,13 @@ class MultiProcess(events.Plugin):
 
     def _prepConns(self):
         """
-        If the bind_host is not none, return:
+        If the ``bind_host`` is not ``None``, return:
             (multiprocessing.connection.Listener, (address, port, authkey))
         else:
             (parent_connection, child_connection)
 
-        For the former case: accept must be called on the listener. In order
-        to get a Connection object for the socket.
+        For the former case: ``accept`` must be called on the listener. In order
+        to get a ``Connection`` object for the socket.
         """
         if self.bind_host is not None:
             #prevent "accidental" wire crossing
@@ -139,10 +139,10 @@ class MultiProcess(events.Plugin):
 
     def _acceptConns(self, parent_conn):
         """
-        When listener is is a connection.Listener instance: accept the next
-        incoming connection.  However, a timeout mechanism is needed.  Since,
-        this functionality was added to support mp over inet sockets, will
-        assume a Socket based listen and will accept the private _socket
+        When listener is is a :class:`connection.Listener` instance: accept the next
+        incoming connection.  However, a timeout mechanism is needed.  Since
+        this functionality was added to support mp over inet sockets, this method
+        assumes a Socket-based listen, and will accept the private _socket
         member to get a low_level socket to do a select on.
         """
         if isinstance(parent_conn, connection.Listener):

--- a/nose2/plugins/printhooks.py
+++ b/nose2/plugins/printhooks.py
@@ -8,7 +8,7 @@ the event that was passed to the hook.
 To do that, this plugin overrides :meth:`nose2.events.Plugin.register`
 and, after registration, replaces all existing
 :class:`nose2.events.Hook` instances in ``session.hooks`` with
-instances of a Hook subclass that prints information about each call.
+instances of a :class:`~nose2.events.Hook` subclass that prints information about each call.
 """
 import sys
 
@@ -30,7 +30,7 @@ class PrintHooks(events.Plugin):
     def register(self):
         """Override to inject noisy hook instances.
 
-        Replaces Hook instances in ``self.session.hooks.hooks`` with
+        Replaces :class:`~nose2.events.Hook` instances in ``self.session.hooks.hooks`` with
         noisier objects.
 
         """

--- a/nose2/plugins/result.py
+++ b/nose2/plugins/result.py
@@ -5,7 +5,7 @@ This plugin implements the primary user interface for nose2. It
 collects test outcomes and reports on them to the console, as well as
 firing several hooks for other plugins to do their own reporting.
 
-To see this report, nose2 MUST be run with the "verbose" flag::
+To see this report, nose2 MUST be run with the :option:`verbose` flag::
 
   nose2 --verbose
 
@@ -16,9 +16,9 @@ want. Note, however, that customer categories are *not* treated as
 errors or failures for the purposes of determining whether a test run
 has succeeded.
 
-Don't disable this plugin unless you a) have another one doing the
-same job or b) really don't want any test results (and want all test
-runs to exit(1))
+Don't disable this plugin, unless you (a) have another one doing the
+same job, or (b) really don't want any test results (and want all test
+runs to ``exit(1)``).
 """
 # This module contains some code copied from unittest2/runner.py and other
 # code developed in reference to that module and others within unittest2.

--- a/nose2/result.py
+++ b/nose2/result.py
@@ -15,14 +15,14 @@ class PluggableTestResult(object):
     """Test result that defers to plugins.
 
     All test outcome recording and reporting is deferred to plugins,
-    which are expected to implement startTest, stopTest, testOutcome,
-    and wasSuccessful.
+    which are expected to implement :func:`startTest`, :func:`stopTest`, 
+    :func:`testOutcome`, and :func:`wasSuccessful`.
 
     :param session: Test run session.
 
     .. attribute :: shouldStop
 
-       When True, test run should stop before running another test.
+       When ``True``, test run should stop before running another test.
 
     """
 
@@ -111,10 +111,10 @@ class PluggableTestResult(object):
     def wasSuccessful(self):
         """Was test run successful?
 
-        Fires :func:`wasSuccessful` hook, returns ``event.success``.
+        Fires :func:`wasSuccessful` hook, and returns ``event.success``.
 
         """
-        # assume failure, plugins must affirmatively declare success
+        # assume failure; plugins must explicitly declare success
         try:
             return self._success
         except AttributeError:
@@ -126,7 +126,7 @@ class PluggableTestResult(object):
     def stop(self):
         """Stop test run.
 
-        Fires :func:`resultStop` hook, sets ``self.shouldStop`` to
+        Fires :func:`resultStop` hook, and sets ``self.shouldStop`` to
         ``event.shouldStop``.
 
         """

--- a/nose2/runner.py
+++ b/nose2/runner.py
@@ -31,7 +31,7 @@ class PluggableTestRunner(object):
     def run(self, test):
         """Run tests.
 
-        :param test: A unittest TestSuite or TestClass.
+        :param test: A unittest :class:`TestSuite`` or :class:`TestClass`.
         :returns: Test result
 
         Fires :func:`startTestRun` and :func:`stopTestRun` hooks.

--- a/nose2/session.py
+++ b/nose2/session.py
@@ -211,7 +211,7 @@ class Session(object):
         return self.get('unittest')
 
     def isPluginLoaded(self, pluginName):
-        """Returns True if a given plugin is loaded.
+        """Returns ``True`` if a given plugin is loaded.
 
         :param pluginName: the name of the plugin module: e.g. "nose2.plugins.layers".
 

--- a/nose2/sphinxext.py
+++ b/nose2/sphinxext.py
@@ -101,7 +101,7 @@ class AutoPlugin(Directive):
 
         self.headline(rst, u"Sample configuration", '-')
         rst.append(u'The default configuration is equivalent to including '
-                   u'the following in a unittest.cfg file.', AD)
+                   u'the following in a :file:`unittest.cfg` file.', AD)
         rst.append(u'', AD)
         rst.append(u'.. code-block:: ini', AD)
         rst.append(u'  ', AD)

--- a/nose2/suite.py
+++ b/nose2/suite.py
@@ -120,8 +120,8 @@ class LayerSuite(unittest.BaseTestSuite):
 
     def _getBoundClassmethod(self, cls, method):
         """
-        Use instead of getattr to get only classmethods explicitly defined
-        on cls (not methods inherited from ancestors)
+        Use instead of :func:`getattr` to get only classmethods explicitly defined
+        on ``cls`` (not methods inherited from ancestors)
         """
         descriptor = cls.__dict__.get(method, None)
         if descriptor:

--- a/nose2/tests/_common.py
+++ b/nose2/tests/_common.py
@@ -19,7 +19,7 @@ class TestCase(unittest.TestCase):
 
     """TestCase extension.
 
-    If the class variable _RUN_IN_TEMP is True (default: False), tests will be
+    If the class variable ``_RUN_IN_TEMP`` is ``True`` (default: ``False``), tests will be
     performed in a temporary directory, which is deleted afterwards.
     """
     _RUN_IN_TEMP = False
@@ -72,7 +72,7 @@ class FunctionalTestCase(unittest.TestCase):
 
 class _FakeEventBase(object):
 
-    """Baseclass for fake Events."""
+    """Baseclass for fake :class:`~nose2.events.Event`\s."""
 
     def __init__(self):
         self.handled = False
@@ -95,7 +95,7 @@ class FakeHandleFileEvent(_FakeEventBase):
 
 class FakeStartTestEvent(_FakeEventBase):
 
-    """Fake StartTestEvent."""
+    """Fake :class:`~nose2.events.StartTestEvent`."""
 
     def __init__(self, test):
         super(FakeStartTestEvent, self).__init__()
@@ -107,7 +107,7 @@ class FakeStartTestEvent(_FakeEventBase):
 
 class FakeLoadFromNameEvent(_FakeEventBase):
 
-    """Fake LoadFromNameEvent."""
+    """Fake :class:`~nose2.events.LoadFromNameEvent`."""
 
     def __init__(self, name):
         super(FakeLoadFromNameEvent, self).__init__()
@@ -116,7 +116,7 @@ class FakeLoadFromNameEvent(_FakeEventBase):
 
 class FakeLoadFromNamesEvent(_FakeEventBase):
 
-    """Fake LoadFromNamesEvent."""
+    """Fake :class:`~nose2.events.LoadFromNamesEvent`."""
 
     def __init__(self, names):
         super(FakeLoadFromNamesEvent, self).__init__()
@@ -125,7 +125,7 @@ class FakeLoadFromNamesEvent(_FakeEventBase):
 
 class FakeStartTestRunEvent(_FakeEventBase):
 
-    """Fake StartTestRunEvent"""
+    """Fake :class:`~nose2.events.StartTestRunEvent`"""
 
     def __init__(self, runner=None, suite=None, result=None, startTime=None,
                  executeTests=None):
@@ -215,7 +215,7 @@ class NotReallyAProc(object):
 class RedirectStdStreams(object):
 
     """
-    Context manager that replaces the stdin/out streams with StringIO
+    Context manager that replaces the stdin/stdout streams with :class:`StringIO`
     buffers.
     """
 

--- a/nose2/tools/decorators.py
+++ b/nose2/tools/decorators.py
@@ -5,7 +5,7 @@ This module provides decorators that assist the test author to write tests.
 
 def with_setup(setup):
     """
-    A decorator that sets the setup method to be executed before the test.
+    A decorator that sets the :func:`setup` method to be executed before the test.
 
     It currently works only for function test cases.
 
@@ -23,7 +23,7 @@ def with_setup(setup):
 
 def with_teardown(teardown):
     """
-    A decorator that sets the teardown method to be after before the test.
+    A decorator that sets the :func:`teardown` method to be after before the test.
 
     It currently works only for function test cases.
 

--- a/nose2/tools/params.py
+++ b/nose2/tools/params.py
@@ -1,6 +1,6 @@
 """
-This module contains some code copied from unittest2 and other
-code developed in reference to unittest2.
+This module contains some code copied from :mod:`unittest2` and other
+code developed in reference to :mod:`unittest2`.
 
 unittest2 is Copyright (c) 2001-2010 Python Software Foundation; All
 Rights Reserved. See: http://docs.python.org/license.html
@@ -33,8 +33,8 @@ def cartesian_params(*paramList):
           def test_less_than(self, num, char):
               self.assertLess(num, ord(char))
 
-    Parameters in the list must be defined as iterable objects such as
-    tuple or list.
+    Parameters in the list must be defined as iterable objects (such as
+    ``tuple`` or ``list``).
 
     """
     def decorator(func):

--- a/nose2/tools/such.py
+++ b/nose2/tools/such.py
@@ -78,12 +78,12 @@ class Scenario(object):
         self._group.mixins.append(layer)
 
     def has_setup(self, func):
-        """Add a setup method to this group.
+        """Add a :func:`setup` method to this group.
 
-        The setup method will run once, before any of the
+        The :func:`setup` method will run once, before any of the
         tests in the containing group.
 
-        A group may define any number of setup functions. They
+        A group may define any number of :func:`setup` functions. They
         will execute in the order in which they are defined.
 
         .. code-block :: python
@@ -97,12 +97,12 @@ class Scenario(object):
         return func
 
     def has_teardown(self, func):
-        """Add a teardown method to this group.
+        """Add a :func:`teardown` method to this group.
 
-        The teardown method will run once, after all of the
+        The :func:`teardown` method will run once, after all of the
         tests in the containing group.
 
-        A group may define any number of teardown functions. They
+        A group may define any number of :func:`teardown` functions. They
         will execute in the order in which they are defined.
 
         .. code-block :: python
@@ -116,16 +116,16 @@ class Scenario(object):
         return func
 
     def has_test_setup(self, func):
-        """Add a test case setup method to this group.
+        """Add a test case :func:`setup` method to this group.
 
-        The setup method will run before each of the
+        The :func:`setup` method will run before each of the
         tests in the containing group.
 
-        A group may define any number of test case setup
+        A group may define any number of test case :func:`setup`
         functions. They will execute in the order in which they are
         defined.
 
-        Test setup functions may optionally take one argument. If
+        Test :func:`setup` functions may optionally take one argument. If
         they do, they will be passed the :class:`unittest.TestCase`
         instance generated for the test.
 
@@ -139,16 +139,16 @@ class Scenario(object):
         self._group.addTestSetUp(func)
 
     def has_test_teardown(self, func):
-        """Add a test case teardown method to this group.
+        """Add a test case :func:`teardown` method to this group.
 
-        The teardown method will run before each of the
+        The :func:`teardown` method will run before each of the
         tests in the containing group.
 
-        A group may define any number of test case teardown
+        A group may define any number of test case :func:`teardown`
         functions. They will execute in the order in which they are
         defined.
 
-        Test teardown functions may optionally take one argument. If
+        Test :func:`teardown` functions may optionally take one argument. If
         they do, they will be passed the :class:`unittest.TestCase`
         instance generated for the test.
 
@@ -206,10 +206,9 @@ class Scenario(object):
 
         .. warning ::
 
-           You must call this, passing in ``globals()``, to
-           generate tests from the scenario. If you don't
-           call ``createTests``, **no tests will be
-           created**.
+           You must call this, passing in :func:`globals`, to
+           generate tests from the scenario. If you don't,
+           **no tests will be created**.
 
         .. code-block :: python
 
@@ -252,7 +251,7 @@ class Scenario(object):
 
         def _make_test_func(case):
             '''
-            Needs to be outside of the for-loop scope so that "case" is properly registered as a closure
+            Needs to be outside of the for-loop scope, so that ``case`` is properly registered as a closure.
             '''
             def _test(s, *args):
                 case(s, *args)
@@ -346,7 +345,7 @@ class Scenario(object):
 
 class Group(object):
 
-    """Group of tests w/common fixtures & description"""
+    """A group of tests, with common fixtures and description"""
 
     def __init__(self, description, indent=0, parent=None, base_layer=None):
         self.description = description

--- a/nose2/util.py
+++ b/nose2/util.py
@@ -35,12 +35,12 @@ VALID_MODULE_RE = re.compile(r'[_a-zA-Z]\w*\.py$', re.UNICODE)
 
 
 def ln(label, char='-', width=70):
-    """Draw a divider, with label in the middle.
+    """Draw a divider, with ``label`` in the middle.
 
     >>> ln('hello there')
     '---------------------------- hello there -----------------------------'
 
-    Width and divider char may be specified. Defaults are 70 and '-'
+    ``width`` and divider ``char`` may be specified. Defaults are ``70`` and ``'-'``,
     respectively.
 
     """
@@ -54,18 +54,20 @@ def ln(label, char='-', width=70):
 
 
 def valid_module_name(path):
-    """Is path a valid module name?"""
+    """Is ``path`` a valid module name?"""
     return VALID_MODULE_RE.search(path)
 
 
 def name_from_path(path):
-    """Translate path into module name
+    """Translate ``path`` into module name
 
-    Returns a two-element tuple. The first element is a dotted
-    module name that can be used in import statement,
-    e.g. pkg1.test.test_things.
-    The second element is a full path to filesystem directory
-    that must be on sys.path in order for the import to succeed.
+    Returns a two-element tuple: 
+    
+    1. a dotted module name that can be used in an import statement
+       (e.g., ``pkg1.test.test_things``)
+    
+    2. a full path to filesystem directory, which must be on ``sys.path`` 
+       for the import to succeed.
 
     """
     # back up to find module root
@@ -84,13 +86,13 @@ def name_from_path(path):
 
 
 def module_from_name(name):
-    """Import module from name"""
+    """Import module from ``name``"""
     __import__(name)
     return sys.modules[name]
 
 
 def test_from_name(name, module):
-    """Import test from name"""
+    """Import test from ``name``"""
     pos = name.find(':')
     index = None
     if pos != -1:
@@ -106,7 +108,7 @@ def test_from_name(name, module):
 
 
 def object_from_name(name, module=None):
-    """Import object from name"""
+    """Import object from ``name``"""
     parts = name.split('.')
     if module is None:
         parts_copy = parts[:]
@@ -134,7 +136,7 @@ def name_from_args(name, index, args):
 
 
 def test_name(test):
-    # XXX does not work for test funcs, test.id() lacks module
+    # XXX does not work for test funcs; test.id() lacks module
     if hasattr(test, '_funcName'):
         tid = test._funcName
     elif hasattr(test, '_testFunc'):
@@ -163,13 +165,13 @@ def ispackage(path):
 
 
 def ensure_importable(dirname):
-    """Ensure a directory is on sys.path"""
+    """Ensure a directory is on ``sys.path``."""
     if dirname not in sys.path:
         sys.path.insert(0, dirname)
 
 
 def isgenerator(obj):
-    """is this object a generator?"""
+    """Is this object a generator?"""
     return (isgeneratorfunction(obj)
             or getattr(obj, 'testGenerator', None) is not None)
 
@@ -185,9 +187,9 @@ def has_module_fixtures(test):
 
 
 def has_class_fixtures(test):
-    # hasattr would be the obvious thing to use here, unfortunately all tests
-    # inherit from unittest2.case.TestCase and that *always* has setUpClass and
-    # tearDownClass methods. Therefore will have the following (ugly) solution:
+    # hasattr would be the obvious thing to use here. Unfortunately, all tests
+    # inherit from unittest2.case.TestCase, and that *always* has setUpClass and
+    # tearDownClass methods. Thus, the following (ugly) solution:
     ver = platform.python_version_tuple()
     if float('{0}.{1}'.format(*ver[:2])) >= 2.7:
         name = 'unittest.case'
@@ -226,7 +228,7 @@ def exc_info_to_string(err, test):
 
 
 def format_traceback(test, err):
-    """Converts a sys.exc_info()-style tuple of values into a string."""
+    """Converts a :func:`sys.exc_info` -style tuple of values into a string."""
     exctype, value, tb = err
     if not hasattr(tb, 'tb_next'):
         msgLines = tb
@@ -246,7 +248,7 @@ def format_traceback(test, err):
 
 
 def transplant_class(cls, module):
-    """Make class appear to reside in ``module``.
+    """Make ``cls`` appear to reside in ``module``.
 
     :param cls: A class
     :param module: A module name
@@ -286,7 +288,7 @@ def _count_relevant_tb_levels(tb):
 
 class _WritelnDecorator(object):
 
-    """Used to decorate file-like objects with a handy 'writeln' method"""
+    """Used to decorate file-like objects with a handy :func:`writeln` method"""
 
     def __init__(self, stream):
         self.stream = stream


### PR DESCRIPTION
Last time (PR #239), I updated docs under the `docs/` directory.  Since lots of documentation is drawn from the docstrings in the source, I’ve done similar work to my last Pull Request for the docstrings in the source files.

----

I mostly added markup, as follows:

- I tried to use `:role:` directives wherever I could
- If I wasn’t sure which role to use, I used double backticks

Besides that, I made a few (very) limited edits to text.  These are all minor, and chiefly motivated by phrasing and clarity.

Hope you like it!