### PR TITLE
Add layer fixture events and hooks

### DIFF
--- a/docs/dev/hook_reference.rst
+++ b/docs/dev/hook_reference.rst
@@ -166,6 +166,38 @@ These hooks are called for registered plugins only.
    To prevent the test executor from running at all, set
    ``event.handled`` to ``True``.
 
+.. function :: startLayerSetup(self, event)
+
+   :param event: A :class:`nose2.events.StartLayerSetupEvent` instance (only
+   available in suites with layers).
+
+   Plugins can use this hook to take action before the start of the ``setUp``
+   in a layer.
+
+.. function :: stopLayerSetup(self, event)
+
+   :param event: A :class:`nose2.events.StopLayerSetupEvent` instance (only
+   available in suites with layers).
+
+   Plugins can use this hook to take action after ``setUp`` finishes, in a
+   layer.
+
+.. function :: startLayerSetupTest(self, event)
+
+   :param event: A :class:`nose2.events.StartLayerSetupTestEvent` instance
+   (only available in suites with layers).
+
+   Plugins can use this hook to take action before the start of ``testSetUp``
+   in a layer.
+
+.. function :: stopLayerSetupTest(self, event)
+
+   :param event: A :class:`nose2.events.StopLayerSetupTestEvent` instance (only
+   available in suites with layers).
+
+   Plugins can use this hook to take action after ``testSetUp`` finishes, in a
+   layer.
+
 .. function :: startTest(self, event)
 
    :param event: A :class:`nose2.events.StartTestEvent` instance
@@ -285,6 +317,38 @@ These hooks are called for registered plugins only.
 
    Plugins can use this hook to take action after a test has completed
    running and reported its outcome.
+
+.. function :: startLayerTeardownTest(self, event)
+
+   :param event: A :class:`nose2.events.StartLayerTeardownTestEvent` instance
+   (only available in suites with layers).
+
+   Plugins can use this hook to take action before the start of
+   ``testTearDown()`` in a layer.
+
+.. function :: stopLayerTeardownTest(self, event)
+
+   :param event: A :class:`nose2.events.StopLayerTeardownTestEvent` instance
+   (only available in suites with layers).
+
+   Plugins can use this hook to take action after ``testTearDown()`` finishes,
+   in a layer.
+
+.. function :: startLayerTeardown(self, event)
+
+   :param event: A :class:`nose2.events.StartLayerTeardownEvent` instance (only
+   available in suites with layers).
+
+   Plugins can use this hook to take action before the start of the
+   ``tearDown()`` in a layer.
+
+.. function :: stopLayerTeardown(self, event)
+
+   :param event: A :class:`nose2.events.StopLayerTeardownEvent` instance (only
+   available in suites with layers).
+
+   Plugins can use this hook to take action after ``tearDown()`` finishes, in a
+   layer.
 
 .. function :: stopTestRun(self, event)
 

--- a/docs/plugins/layers.rst
+++ b/docs/plugins/layers.rst
@@ -6,69 +6,71 @@ Organizing Test Fixtures into Layers
 
    New in version 0.4
 
-Layers allow more flexible organization of test fixtures than test-,
-class- and module- level fixtures. Layers in nose2 are inspired by
-and aim to be compatible with the layers used by Zope's testrunner.
+Layers allow more flexible organization of test fixtures than test-, class- and
+module- level fixtures. Layers in nose2 are inspired by and aim to be
+compatible with the layers used by Zope's testrunner.
 
 Using layers, you can do things like:
 
-* Implement package-level fixtures by sharing a layer among all
-  test cases in the package.
+* Implement package-level fixtures by sharing a layer among all test cases in
+  the package.
 
-* Share fixtures across tests in different modules without
-  having them run multiple times.
+* Share fixtures across tests in different modules without having them run
+  multiple times.
 
-* Create a fixture tree deeper than three levels (test, class and
-  module).
+* Create a fixture tree deeper than three levels (test, class and module).
 
 * Make fixtures available for other packages or projects to use.
 
 A layer is a *new-style* class that implements at least a ``setUp``
 classmethod:
 
-.. code-block :: python
+.. code-block:: python
 
-  class Layer(object):
-      @classmethod
-      def setUp(cls):
-          # ...
+    class Layer(object):
+       @classmethod
+       def setUp(cls):
+           # ...
 
-It may also implement ``tearDown``, ``testSetUp`` and
-``testTearDown``, all as classmethods.
+It may also implement ``tearDown``, ``testSetUp`` and ``testTearDown``, all as
+classmethods.
 
-To assign a layer to a test case, set the test case's ``layer``
-property::
+To assign a layer to a test case, set the test case's ``layer`` property:
 
-  class Test(unittest.TestCase):
-      layer = Layer
+.. code-block:: python
 
-Note that the layer *class* is assigned, not an instance of the
-layer. Typically layer classes are not instantiated.
+    class Test(unittest.TestCase):
+        layer = Layer
+
+Note that the layer *class* is assigned, not an instance of the layer.
+Typically layer classes are not instantiated.
 
 Sub-layers
 ==========
 
 Layers may subclass other layers:
 
-.. code-block :: python
+.. code-block:: python
 
-  class SubLayer(Layer):
-      @classmethod
-      def setUp(cls):
-          # ...
+    class SubLayer(Layer):
+        @classmethod
+        def setUp(cls):
+            # ...
 
-In this case, all tests that belong to the sub-layer also belong to
-the base layer. For example for this test case::
+In this case, all tests that belong to the sub-layer also belong to the base
+layer. For example for this test case:
 
-  class SubTest(unittest.TestCase):
-      layer = SubLayer
+.. code-block:: python
 
-The ``setUp`` methods from *both* ``SubLayer`` and ``Layer`` will run
-before any tests are run. The superclass's setup will always run
-before the subclass's setup. For ``teardown``, the reverse: the subclass's
-``teardown`` runs before the superclass's.
+    class SubTest(unittest.TestCase):
+        layer = SubLayer
 
-.. warning ::
+The ``setUp`` methods from *both* ``SubLayer`` and ``Layer`` will run before
+any tests are run. The superclass's setup will always run before the subclass's
+setup. For ``teardown``, the reverse: the subclass's ``teardown`` runs before
+the superclass's.
+
+.. warning::
 
    One important thing to note: layers that subclass other layers *must
    not* call their superclass's ``setUp``, ``tearDown``, etc. The test
@@ -94,21 +96,21 @@ before the subclass's setup. For ``teardown``, the reverse: the subclass's
 Layer method reference
 ======================
 
-.. class :: Layer
+.. class:: Layer
 
    Not an actual class, but reference documentation for
    the methods layers can implement. There is no layer
    base class. Layers must be subclasses of :class:`object`
    or other layers.
 
-   .. classmethod :: setUp(cls)
+   .. classmethod:: setUp(cls)
 
       The layer's ``setUp`` method is called before any tests belonging to
       that layer are executed. If no tests belong to the layer (or one of
       its sub-layers) then the ``setUp`` method will not
       be called.
 
-   .. classmethod :: tearDown(cls)
+   .. classmethod:: tearDown(cls)
 
       The layer's ``tearDown`` method is called after any tests
       belonging to the layer are executed, if the layer's ``setUp``
@@ -116,7 +118,7 @@ Layer method reference
       be called if the layer has no ``setUp`` method, or if that
       method did not run or did raise an exception.
 
-   .. classmethod :: testSetUp(cls[, test])
+   .. classmethod:: testSetUp(cls[, test])
 
       The layer's ``testSetUp`` method is called before each test
       belonging to the layer (and its sub-layers). If
@@ -124,7 +126,7 @@ Layer method reference
       instance is passed to the method. The method may also be
       defined to take no arguments.
 
-   .. classmethod :: testTearDown(cls[, test])
+   .. classmethod:: testTearDown(cls[, test])
 
       The layer's ``testTearDown`` method is called after each test
       belonging to the layer (and its sub-layers), if
@@ -189,11 +191,11 @@ with the :doc:`such DSL <../such_dsl>`.
 
 If you would like to change how the layer is displayed, set the ``description`` attribute.
 
-.. code-block :: python
+.. code-block:: python
 
   class LayerD(Layer):
       description = '*** This is a very important custom layer description ***'
-      
+
 Now the output will be the following::
 
 

--- a/nose2/events.py
+++ b/nose2/events.py
@@ -75,7 +75,8 @@ class Plugin(six.with_metaclass(PluginMeta)):
 
        Example::
 
-         commandLineSwitch = ('B', 'buffer-output', 'Buffer output during tests')
+         commandLineSwitch = ('B', 'buffer-output', 'Buffer output during
+         tests')
 
     .. attribute :: configSection
 
@@ -260,12 +261,14 @@ class PluginInterface(object):
     """
     preRegistrationMethods = ('pluginsLoaded', 'handleArgs')
     methods = (
-        'loadTestsFromModule', 'loadTestsFromNames',
-        'handleFile', 'startTestRun', 'startTest', 'stopTest',
-        'loadTestsFromName', 'loadTestsFromTestCase',
-        'stopTestRun', 'matchPath', 'matchDirPath', 'getTestCaseNames',
-        'runnerCreated', 'resultCreated', 'testOutcome', 'wasSuccessful',
-        'resultStop', 'setTestOutcome', 'describeTest',
+        'loadTestsFromModule', 'loadTestsFromNames', 'handleFile',
+        'startLayerSetup', 'startLayerSetupTest', 'stopLayerSetupTest',
+        'stopLayerSetup', 'startTestRun', 'startTest', 'stopTest',
+        'startLayerTeardown', 'startLayerTeardownTest',
+        'stopLayerTeardownTest', 'stopLayerTeardown', 'loadTestsFromName',
+        'loadTestsFromTestCase', 'stopTestRun', 'matchPath', 'matchDirPath',
+        'getTestCaseNames', 'runnerCreated', 'resultCreated', 'testOutcome',
+        'wasSuccessful', 'resultStop', 'setTestOutcome', 'describeTest',
         'reportStartTest', 'reportError', 'reportFailure', 'reportSkip',
         'reportSuccess', 'reportExpectedFailure', 'reportUnexpectedSuccess',
         'reportOtherOutcome', 'outcomeDetail', 'beforeErrorList',
@@ -405,6 +408,146 @@ class ResultCreatedEvent(Event):
     def __init__(self, result, **kw):
         self.result = result
         super(ResultCreatedEvent, self).__init__(**kw)
+
+
+class StartLayerSetupEvent(Event):
+
+    """Event fired before running a layer setup.
+
+    .. attribute :: layer
+
+       The current layer instance, for which setup is about to run.
+    """
+    _attrs = Event._attrs + ('layer',)
+
+    def __init__(self, layer, **kw):
+        self.layer = layer
+        super(StartLayerSetupEvent, self).__init__(**kw)
+
+
+class StopLayerSetupEvent(Event):
+
+    """Event fired after running a layer setup.
+
+    .. attribute :: layer
+
+       The current layer instance, for which setup just ran.
+    """
+    _attrs = Event._attrs + ('layer',)
+
+    def __init__(self, layer, **kw):
+        self.layer = layer
+        super(StopLayerSetupEvent, self).__init__(**kw)
+
+
+class StartLayerSetupTestEvent(Event):
+
+    """Event fired before test cases setups in layers.
+
+    .. attribute :: layer
+
+       The current layer instance.
+
+    .. attribute :: test
+
+       The test instance for which the setup is about to run.
+    """
+    _attrs = Event._attrs + ('layer', 'test')
+
+    def __init__(self, layer, test, **kw):
+        self.layer = layer
+        self.test = test
+        super(StartLayerSetupTestEvent, self).__init__(**kw)
+
+
+class StopLayerSetupTestEvent(Event):
+
+    """Event fired after test cases setups in layers.
+
+    .. attribute :: layer
+
+       The current layer instance.
+
+    .. attribute :: test
+
+       The test instance for which the setup just finished.
+    """
+    _attrs = Event._attrs + ('layer', 'test')
+
+    def __init__(self, layer, test, **kw):
+        self.layer = layer
+        self.test = test
+        super(StopLayerSetupTestEvent, self).__init__(**kw)
+
+
+class StartLayerTeardownEvent(Event):
+
+    """Event fired before running a layer teardown.
+
+    .. attribute :: layer
+
+       The current layer instance, for which teardown is about to run.
+    """
+    _attrs = Event._attrs + ('layer',)
+
+    def __init__(self, layer, **kw):
+        self.layer = layer
+        super(StartLayerTeardownEvent, self).__init__(**kw)
+
+
+class StopLayerTeardownEvent(Event):
+
+    """Event fired after running a layer teardown.
+
+    .. attribute :: layer
+
+       The current layer instance, for which teardown just ran.
+    """
+    _attrs = Event._attrs + ('layer',)
+
+    def __init__(self, layer, **kw):
+        self.layer = layer
+        super(StopLayerTeardownEvent, self).__init__(**kw)
+
+
+class StartLayerTeardownTestEvent(Event):
+
+    """Event fired before test cases teardowns in layers.
+
+    .. attribute :: layer
+
+       The current layer instance.
+
+    .. attribute :: test
+
+       The test instance for which teardown is about to run.
+    """
+    _attrs = Event._attrs + ('layer', 'test')
+
+    def __init__(self, layer, test, **kw):
+        self.layer = layer
+        self.test = test
+        super(StartLayerTeardownTestEvent, self).__init__(**kw)
+
+
+class StopLayerTeardownTestEvent(Event):
+
+    """Event fired after test cases teardowns in layers.
+
+    .. attribute :: layer
+
+       The current layer instance.
+
+    .. attribute :: test
+
+       The test instance for which teardown just ran.
+    """
+    _attrs = Event._attrs + ('layer', 'test')
+
+    def __init__(self, layer, test, **kw):
+        self.layer = layer
+        self.test = test
+        super(StopLayerTeardownTestEvent, self).__init__(**kw)
 
 
 class StartTestRunEvent(Event):

--- a/nose2/tests/functional/support/lib/layer_hooks_plugin.py
+++ b/nose2/tests/functional/support/lib/layer_hooks_plugin.py
@@ -1,0 +1,34 @@
+import six
+from nose2 import events
+
+
+class PrintFixture(events.Plugin):
+    alwaysOn = True
+
+    def startLayerSetup(self, event):
+        six.print_("StartLayerSetup: {0}".format(event.layer))
+
+    def stopLayerSetup(self, event):
+        six.print_("StopLayerSetup: {0}".format(event.layer))
+
+    def startLayerSetupTest(self, event):
+        log = "StartLayerSetupTest: {0}:{1}"
+        six.print_(log.format(event.layer, event.test))
+
+    def stopLayerSetupTest(self, event):
+        log = "StopLayerSetupTest: {0}:{1}"
+        six.print_(log.format(event.layer, event.test))
+
+    def startLayerTeardownTest(self, event):
+        log = "StartLayerTeardownTest: {0}:{1}"
+        six.print_(log.format(event.layer, event.test))
+
+    def stopLayerTeardownTest(self, event):
+        log = "StopLayerTeardownTest: {0}:{1}"
+        six.print_(log.format(event.layer, event.test))
+
+    def startLayerTeardown(self, event):
+        six.print_("StartLayerTeardown: {0}".format(event.layer))
+
+    def stopLayerTeardown(self, event):
+        six.print_("StopLayerTeardown: {0}".format(event.layer))

--- a/nose2/tests/functional/support/scenario/layers_hooks/test_layers_simple.py
+++ b/nose2/tests/functional/support/scenario/layers_hooks/test_layers_simple.py
@@ -1,0 +1,53 @@
+from nose2.compat import unittest
+
+
+class Layer1(object):
+
+    layer_setup = 0
+    test_setup = 0
+    test_teardown = 0
+    layer_teardown = 0
+    tests_count = 0
+
+    @classmethod
+    def setUp(cls):
+        if cls.layer_setup >= 1:
+            raise Exception('layer_setup already ran')
+        cls.layer_setup += 1
+
+    @classmethod
+    def testSetUp(cls):
+        if cls.test_setup >= 2:
+            raise Exception('test_setup already ran twice')
+        cls.test_setup += 1
+
+    @classmethod
+    def testTearDown(cls):
+        if cls.test_teardown >= 2:
+            raise Exception('test_teardown already ran twice')
+        cls.test_teardown += 1
+
+    @classmethod
+    def tearDown(cls):
+        if cls.layer_teardown >= 1:
+            raise Exception('layer_teardown already ran')
+        cls.layer_teardown += 1
+
+
+class TestSimple(unittest.TestCase):
+
+    layer = Layer1
+
+    def test_1(self):
+        assert self.layer.layer_setup == 1
+        assert self.layer.test_setup == self.layer.tests_count + 1
+        assert self.layer.test_teardown == self.layer.tests_count
+        assert self.layer.layer_teardown == 0
+        self.layer.tests_count += 1
+
+    def test_2(self):
+        assert self.layer.layer_setup == 1
+        assert self.layer.test_setup == self.layer.tests_count + 1
+        assert self.layer.test_teardown == self.layer.tests_count
+        assert self.layer.layer_teardown == 0
+        self.layer.tests_count += 1

--- a/nose2/tests/functional/support/scenario/layers_hooks/test_simple_such.py
+++ b/nose2/tests/functional/support/scenario/layers_hooks/test_simple_such.py
@@ -1,0 +1,9 @@
+from nose2.tools import such
+
+with such.A('system') as it:
+
+    @it.should('do something')
+    def test():
+        pass
+
+it.createTests(globals())

--- a/nose2/tests/functional/test_layers_hooks.py
+++ b/nose2/tests/functional/test_layers_hooks.py
@@ -1,0 +1,132 @@
+import sys
+import os
+from nose2.tests._common import FunctionalTestCase
+
+
+class TestLayerHooks(FunctionalTestCase):
+
+    @classmethod
+    def setUp(cls):
+        filepath = os.path.dirname(os.path.realpath(__file__))
+        cls.libpath = os.path.join(filepath, 'support', 'lib')
+        sys.path.append(cls.libpath)
+
+    @classmethod
+    def tearDown(cls):
+        if cls.libpath in sys.path:
+            sys.path.remove(cls.libpath)
+
+    def test_simple_such(self):
+        proc = self.runIn(
+            'scenario/layers_hooks',
+            '--plugin=nose2.plugins.layers',
+            '--plugin=layer_hooks_plugin',
+            'test_simple_such')
+        expected = (
+            "^"
+            "StartLayerSetup: <class 'test_simple_such.A system:layer'>\n"
+            "StopLayerSetup: <class 'test_simple_such.A system:layer'>\n"
+            "StartLayerSetupTest: <class 'test_simple_such.A system:layer'>:test 0000: should do something \(test_simple_such.A system\)\n"
+            "StopLayerSetupTest: <class 'test_simple_such.A system:layer'>:test 0000: should do something \(test_simple_such.A system\)\n"
+            "StartLayerTeardownTest: <class 'test_simple_such.A system:layer'>:test 0000: should do something \(test_simple_such.A system\)\n"
+            "StopLayerTeardownTest: <class 'test_simple_such.A system:layer'>:test 0000: should do something \(test_simple_such.A system\)\n"
+            "StartLayerTeardown: <class 'test_simple_such.A system:layer'>\n"
+            "StopLayerTeardown: <class 'test_simple_such.A system:layer'>\n*"
+            "$")
+        self.assertTestRunOutputMatches(proc, stderr='Ran 1 test')
+        self.assertTestRunOutputMatches(proc, stdout=expected)
+        self.assertEqual(proc.poll(), 0, proc.stderr.getvalue())
+
+    def test_complex_such(self):
+        proc = self.runIn(
+            'such/',
+            '--plugin=nose2.plugins.layers',
+            '--plugin=layer_hooks_plugin',
+            'test_such')
+        expected = (
+            "StartLayerSetup: <class 'test_such.A system with complex setup:layer'>\n"
+            "StopLayerSetup: <class 'test_such.A system with complex setup:layer'>\n"
+            "StartLayerSetupTest: <class 'test_such.A system with complex setup:layer'>:test 0000: should do something \(test_such.A system with complex setup\)\n"
+            "StopLayerSetupTest: <class 'test_such.A system with complex setup:layer'>:test 0000: should do something \(test_such.A system with complex setup\)\n"
+            "StartLayerTeardownTest: <class 'test_such.A system with complex setup:layer'>:test 0000: should do something \(test_such.A system with complex setup\)\n"
+            "StopLayerTeardownTest: <class 'test_such.A system with complex setup:layer'>:test 0000: should do something \(test_such.A system with complex setup\)\n"
+            "StartLayerSetup: <class 'test_such.having an expensive fixture:layer'>\n"
+            "StopLayerSetup: <class 'test_such.having an expensive fixture:layer'>\n"
+            "StartLayerSetupTest: <class 'test_such.having an expensive fixture:layer'>:test 0000: should do more things \(test_such.having an expensive fixture\)\n"
+            "StopLayerSetupTest: <class 'test_such.having an expensive fixture:layer'>:test 0000: should do more things \(test_such.having an expensive fixture\)\n"
+            "StartLayerTeardownTest: <class 'test_such.having an expensive fixture:layer'>:test 0000: should do more things \(test_such.having an expensive fixture\)\n"
+            "StopLayerTeardownTest: <class 'test_such.having an expensive fixture:layer'>:test 0000: should do more things \(test_such.having an expensive fixture\)\n"
+            "StartLayerSetup: <class 'test_such.having another precondtion:layer'>\n"
+            "StopLayerSetup: <class 'test_such.having another precondtion:layer'>\n"
+            "StartLayerSetupTest: <class 'test_such.having another precondtion:layer'>:test 0000: should do that not this \(test_such.having another precondtion\)\n"
+            "StopLayerSetupTest: <class 'test_such.having another precondtion:layer'>:test 0000: should do that not this \(test_such.having another precondtion\)\n"
+            "StartLayerTeardownTest: <class 'test_such.having another precondtion:layer'>:test 0000: should do that not this \(test_such.having another precondtion\)\n"
+            "StopLayerTeardownTest: <class 'test_such.having another precondtion:layer'>:test 0000: should do that not this \(test_such.having another precondtion\)\n"
+            "StartLayerSetupTest: <class 'test_such.having another precondtion:layer'>:test 0001: should do this not that \(test_such.having another precondtion\)\n"
+            "StopLayerSetupTest: <class 'test_such.having another precondtion:layer'>:test 0001: should do this not that \(test_such.having another precondtion\)\n"
+            "StartLayerTeardownTest: <class 'test_such.having another precondtion:layer'>:test 0001: should do this not that \(test_such.having another precondtion\)\n"
+            "StopLayerTeardownTest: <class 'test_such.having another precondtion:layer'>:test 0001: should do this not that \(test_such.having another precondtion\)\n"
+            "StartLayerTeardown: <class 'test_such.having another precondtion:layer'>\n"
+            "StopLayerTeardown: <class 'test_such.having another precondtion:layer'>\n"
+            "StartLayerSetup: <class 'test_such.SomeLayer'>\n"
+            "StopLayerSetup: <class 'test_such.SomeLayer'>\n"
+            "StartLayerSetup: <class 'test_such.having a different precondition:layer'>\n"
+            "StopLayerSetup: <class 'test_such.having a different precondition:layer'>\n"
+            "StartLayerSetupTest: <class 'test_such.having a different precondition:layer'>:test 0000: should do something else \(test_such.having a different precondition\)\n"
+            "StopLayerSetupTest: <class 'test_such.having a different precondition:layer'>:test 0000: should do something else \(test_such.having a different precondition\)\n"
+            "StartLayerTeardownTest: <class 'test_such.having a different precondition:layer'>:test 0000: should do something else \(test_such.having a different precondition\)\n"
+            "StopLayerTeardownTest: <class 'test_such.having a different precondition:layer'>:test 0000: should do something else \(test_such.having a different precondition\)\n"
+            "StartLayerSetupTest: <class 'test_such.having a different precondition:layer'>:test 0001: should have another test \(test_such.having a different precondition\)\n"
+            "StopLayerSetupTest: <class 'test_such.having a different precondition:layer'>:test 0001: should have another test \(test_such.having a different precondition\)\n"
+            "StartLayerTeardownTest: <class 'test_such.having a different precondition:layer'>:test 0001: should have another test \(test_such.having a different precondition\)\n"
+            "StopLayerTeardownTest: <class 'test_such.having a different precondition:layer'>:test 0001: should have another test \(test_such.having a different precondition\)\n"
+            "StartLayerSetupTest: <class 'test_such.having a different precondition:layer'>:test 0002: should have access to an external fixture \(test_such.having a different precondition\)\n"
+            "StopLayerSetupTest: <class 'test_such.having a different precondition:layer'>:test 0002: should have access to an external fixture \(test_such.having a different precondition\)\n"
+            "StartLayerTeardownTest: <class 'test_such.having a different precondition:layer'>:test 0002: should have access to an external fixture \(test_such.having a different precondition\)\n"
+            "StopLayerTeardownTest: <class 'test_such.having a different precondition:layer'>:test 0002: should have access to an external fixture \(test_such.having a different precondition\)\n"
+            "StartLayerSetup: <class 'test_such.having a case inside the external fixture:layer'>\n"
+            "StopLayerSetup: <class 'test_such.having a case inside the external fixture:layer'>\n"
+            "StartLayerSetupTest: <class 'test_such.having a case inside the external fixture:layer'>:test 0000: should still have access to that fixture \(test_such.having a case inside the external fixture\)\n"
+            "StopLayerSetupTest: <class 'test_such.having a case inside the external fixture:layer'>:test 0000: should still have access to that fixture \(test_such.having a case inside the external fixture\)\n"
+            "StartLayerTeardownTest: <class 'test_such.having a case inside the external fixture:layer'>:test 0000: should still have access to that fixture \(test_such.having a case inside the external fixture\)\n"
+            "StopLayerTeardownTest: <class 'test_such.having a case inside the external fixture:layer'>:test 0000: should still have access to that fixture \(test_such.having a case inside the external fixture\)\n"
+            "StartLayerTeardown: <class 'test_such.having a case inside the external fixture:layer'>\n"
+            "StopLayerTeardown: <class 'test_such.having a case inside the external fixture:layer'>\n"
+            "StartLayerTeardown: <class 'test_such.having a different precondition:layer'>\n"
+            "StopLayerTeardown: <class 'test_such.having a different precondition:layer'>\n"
+            "StartLayerTeardown: <class 'test_such.SomeLayer'>\n"
+            "StopLayerTeardown: <class 'test_such.SomeLayer'>\n"
+            "StartLayerTeardown: <class 'test_such.having an expensive fixture:layer'>\n"
+            "StopLayerTeardown: <class 'test_such.having an expensive fixture:layer'>\n"
+            "StartLayerTeardown: <class 'test_such.A system with complex setup:layer'>\n"
+            "StopLayerTeardown: <class 'test_such.A system with complex setup:layer'>\n*"
+            "$"
+        )
+        self.assertTestRunOutputMatches(proc, stderr='Ran 9 tests')
+        self.assertTestRunOutputMatches(proc, stdout=expected)
+        self.assertEqual(proc.poll(), 0, proc.stderr.getvalue())
+
+    def test_simple_layers(self):
+        proc = self.runIn(
+            'scenario/layers_hooks',
+            '--plugin=nose2.plugins.layers',
+            '--plugin=layer_hooks_plugin',
+            'test_layers_simple')
+        expected = (
+            "^"
+            "StartLayerSetup: <class 'test_layers_simple.Layer1'>\n"
+            "StopLayerSetup: <class 'test_layers_simple.Layer1'>\n"
+            "StartLayerSetupTest: <class 'test_layers_simple.Layer1'>:test_1 \(test_layers_simple.TestSimple\)\n"
+            "StopLayerSetupTest: <class 'test_layers_simple.Layer1'>:test_1 \(test_layers_simple.TestSimple\)\n"
+            "StartLayerTeardownTest: <class 'test_layers_simple.Layer1'>:test_1 \(test_layers_simple.TestSimple\)\n"
+            "StopLayerTeardownTest: <class 'test_layers_simple.Layer1'>:test_1 \(test_layers_simple.TestSimple\)\n"
+            "StartLayerSetupTest: <class 'test_layers_simple.Layer1'>:test_2 \(test_layers_simple.TestSimple\)\n"
+            "StopLayerSetupTest: <class 'test_layers_simple.Layer1'>:test_2 \(test_layers_simple.TestSimple\)\n"
+            "StartLayerTeardownTest: <class 'test_layers_simple.Layer1'>:test_2 \(test_layers_simple.TestSimple\)\n"
+            "StopLayerTeardownTest: <class 'test_layers_simple.Layer1'>:test_2 \(test_layers_simple.TestSimple\)\n"
+            "StartLayerTeardown: <class 'test_layers_simple.Layer1'>\n"
+            "StopLayerTeardown: <class 'test_layers_simple.Layer1'>\n*"
+            "$")
+        self.assertTestRunOutputMatches(proc, stderr='Ran 2 tests')
+        self.assertTestRunOutputMatches(proc, stdout=expected)
+        self.assertEqual(proc.poll(), 0, proc.stderr.getvalue())


### PR DESCRIPTION
    Add eight events and their associated hooks, when using layers.

    - StartLayerSetupEvent : called before each layer level setup
    - StopLayerSetupEvent : called after each layer level setup
    - StartLayerSetupTestEvent: called before each testcase setup in a
      layer
    - StopLayerSetupTestEvent: called after each testcase setup in a
      layer
    - StartLayerTeardownEvent : called before each layer level teardown
    - StopLayerTeardownEvent : called after each layer level teardown
    - StartLayerTeardownTestEvent: called before each testcase teardown in a
      layer
    - StopLayerTeardownTestEvent: called after each testcase teardown in a
      layer


I'm doing functionnal testing, and thus I use `such` to perform very heavy setups and teardowns. This is reason why I need those hooks. There were apparently planned because I saw in the code `# FIXME : hook call`.

I'm opening the PR because I'd like some feedback before working on tests for this.


Here is a useless plugin that uses those hooks.

```python
# myPlugin.py

from nose2 import events


class PrintFixture(events.Plugin):
    alwaysOn = True

    def startLayerSetup(self, event):
        print "in StartLayerSetup. Layer : %s." % (event.layer.__name__)

    def stopLayerSetup(self, event):
        print "in StopLayerSetup. Layer : %s." % (event.layer.__name__)

    def startLayerSetupTest(self, event):
        print "in StartLayerSetupTest. Layer : %s. Test : %s" % \
            (event.layer.__name__, str(event.test))

    def stopLayerSetupTest(self, event):
        print "in StopLayerSetupTest. Layer : %s. Test : %s" % \
            (event.layer.__name__, str(event.test))

    def startLayerTeardown(self, event):
        print "in StartLayerTeardown. Layer : %s." % (event.layer.__name__)

    def stopLayerTeardown(self, event):
        print "in StopLayerTeardown. Layer : %s." % (event.layer.__name__)

    def startLayerTeardownTest(self, event):
        print "in StartLayerTeardownTest. Layer : %s. Test : %s" % \
            (event.layer.__name__, str(event.test))

    def stopLayerTeardownTest(self, event):
        print "in StopLayerTeardownTest. Layer : %s. Test : %s" % \
           (event.layer.__name__, str(event.test))
```


The test (taken from such documentation) :  

```python

#main.py

import unittest

from nose2.tools import such


class SomeLayer(object):

    @classmethod
    def setUp(cls):
        it.somelayer = True

    @classmethod
    def tearDown(cls):
        del it.somelayer

#
# Such tests start with a declaration about the system under test
# and will typically bind the test declaration to a variable with
# a name that makes nice sentences, like 'this' or 'it'.
#
with such.A('system with complex setup') as it:

    #
    # Each layer of tests can define setup and teardown methods.
    # setup and teardown methods defined here run around the entire
    # group of tests, not each individual test.
    #
    @it.has_setup
    def setup():
        it.things = [1]

    @it.has_teardown
    def teardown():
        it.things = []

    #
    # The 'should' decorator is used to mark tests.
    #
    @it.should('do something')
    def test():
        assert it.things
        #
        # Tests can use all of the normal unittest TestCase assert
        # methods by calling them on the test declaration.
        #
        it.assertEqual(len(it.things), 1)

    #
    # The 'having' context manager is used to introduce a new layer,
    # one that depends on the layer(s) above it. Tests in this
    # new layer inherit all of the fixtures of the layer above.
    #
    with it.having('an expensive fixture'):
        @it.has_setup
        def setup():
            it.things.append(2)

        #
        # Tests that take an argument will be passed the
        # unittest.TestCase instance that is generated to wrap
        # them. Tests can call any and all TestCase methods on this
        # instance.
        #
        @it.should('do more things')
        def test(case):
            case.assertEqual(it.things[-1], 2)

        #
        # Layers can be nested to any depth.
        #
        with it.having('another precondtion'):
            @it.has_setup
            def setup():
                it.things.append(3)

            @it.has_teardown
            def teardown():
                it.things.pop()

            @it.should('do that not this')
            def test(case):
                it.things.append(4)
                #
                # Tests can add their own cleanup functions.
                #
                case.addCleanup(it.things.pop)
                case.assertEqual(it.things[-1], 4, it.things)

            @it.should('do this not that')
            def test(case):
                case.assertEqual(it.things[-1], 3, it.things[:])

        #
        # A layer may have any number of sub-layers.
        #
        with it.having('a different precondition'):

            #
            # A layer defined with ``having`` can make use of
            # layers defined elsewhere. An external layer
            # pulled in with ``it.uses`` becomes a parent
            # of the current layer (though it doesn't actually
            # get injected into the layer's MRO).
            #
            it.uses(SomeLayer)

            @it.has_setup
            def setup():
                it.things.append(99)

            @it.has_teardown
            def teardown():
                it.things.pop()

            #
            # Layers can define setup and teardown methods that wrap
            # each test case, as well, corresponding to TestCase.setUp
            # and TestCase.tearDown.
            #
            @it.has_test_setup
            def test_setup(case):
                it.is_funny = True
                case.is_funny = True

            @it.has_test_teardown
            def test_teardown(case):
                delattr(it, 'is_funny')
                delattr(case, 'is_funny')

            @it.should('do something else')
            def test(case):
                assert it.things[-1] == 99
                assert it.is_funny
                assert case.is_funny

            @it.should('have another test')
            def test(case):
                assert it.is_funny
                assert case.is_funny

            @it.should('have access to an external fixture')
            def test(case):
                assert it.somelayer

            with it.having('a case inside the external fixture'):
                @it.should('still have access to that fixture')
                def test(case):
                    assert it.somelayer

#
# To convert the layer definitions into test cases, you have to call
# `createTests` and pass in the module globals, so that the test cases
# and layer objects can be inserted into the module.
#
it.createTests(globals())
```

Output : 

```
$  nose2 --verbose main --plugin nose2.plugins.layers --plugin myPlugin --layer-reporter
in StartLayerSetup. Layer : A system with complex setup:layer.
in StopLayerSetup. Layer : A system with complex setup:layer.
in StartLayerSetupTest. Layer : A system with complex setup:layer. Test : test 0000: should do something (main.A system with complex setup)
in StopLayerSetupTest. Layer : A system with complex setup:layer. Test : test 0000: should do something (main.A system with complex setup)
A system with complex setup
  should do something ... ok
in StartLayerTeardownTest. Layer : A system with complex setup:layer. Test : test 0000: should do something (main.A system with complex setup)
in StopLayerTeardownTest. Layer : A system with complex setup:layer. Test : test 0000: should do something (main.A system with complex setup)
in StartLayerTeardown. Layer : A system with complex setup:layer.
in StopLayerTeardown. Layer : A system with complex setup:layer.
in StartLayerSetup. Layer : SomeLayer.
in StopLayerSetup. Layer : SomeLayer.
in StartLayerSetup. Layer : having an expensive fixture:layer.
in StopLayerSetup. Layer : having an expensive fixture:layer.
in StartLayerSetupTest. Layer : having an expensive fixture:layer. Test : test 0000: should do more things (main.having an expensive fixture)
in StopLayerSetupTest. Layer : having an expensive fixture:layer. Test : test 0000: should do more things (main.having an expensive fixture)
  having an expensive fixture
    should do more things ... ok
in StartLayerTeardownTest. Layer : having an expensive fixture:layer. Test : test 0000: should do more things (main.having an expensive fixture)
in StopLayerTeardownTest. Layer : having an expensive fixture:layer. Test : test 0000: should do more things (main.having an expensive fixture)
in StartLayerSetup. Layer : having another precondtion:layer.
in StopLayerSetup. Layer : having another precondtion:layer.
in StartLayerSetupTest. Layer : having another precondtion:layer. Test : test 0000: should do that not this (main.having another precondtion)
in StopLayerSetupTest. Layer : having another precondtion:layer. Test : test 0000: should do that not this (main.having another precondtion)
    having another precondtion
      should do that not this ... ok
in StartLayerTeardownTest. Layer : having another precondtion:layer. Test : test 0000: should do that not this (main.having another precondtion)
in StopLayerTeardownTest. Layer : having another precondtion:layer. Test : test 0000: should do that not this (main.having another precondtion)
in StartLayerSetupTest. Layer : having another precondtion:layer. Test : test 0001: should do this not that (main.having another precondtion)
in StopLayerSetupTest. Layer : having another precondtion:layer. Test : test 0001: should do this not that (main.having another precondtion)
      should do this not that ... ok
in StartLayerTeardownTest. Layer : having another precondtion:layer. Test : test 0001: should do this not that (main.having another precondtion)
in StopLayerTeardownTest. Layer : having another precondtion:layer. Test : test 0001: should do this not that (main.having another precondtion)
in StartLayerTeardown. Layer : having another precondtion:layer.
in StopLayerTeardown. Layer : having another precondtion:layer.
in StartLayerSetup. Layer : having a different precondition:layer.
in StopLayerSetup. Layer : having a different precondition:layer.
in StartLayerSetupTest. Layer : having a different precondition:layer. Test : test 0000: should do something else (main.having a different precondition)
in StopLayerSetupTest. Layer : having a different precondition:layer. Test : test 0000: should do something else (main.having a different precondition)
  SomeLayer
    having a different precondition
      should do something else ... ok
in StartLayerTeardownTest. Layer : having a different precondition:layer. Test : test 0000: should do something else (main.having a different precondition)
in StopLayerTeardownTest. Layer : having a different precondition:layer. Test : test 0000: should do something else (main.having a different precondition)
in StartLayerSetupTest. Layer : having a different precondition:layer. Test : test 0001: should have another test (main.having a different precondition)
in StopLayerSetupTest. Layer : having a different precondition:layer. Test : test 0001: should have another test (main.having a different precondition)
      should have another test ... ok
in StartLayerTeardownTest. Layer : having a different precondition:layer. Test : test 0001: should have another test (main.having a different precondition)
in StopLayerTeardownTest. Layer : having a different precondition:layer. Test : test 0001: should have another test (main.having a different precondition)
in StartLayerSetupTest. Layer : having a different precondition:layer. Test : test 0002: should have access to an external fixture (main.having a different precondition)
in StopLayerSetupTest. Layer : having a different precondition:layer. Test : test 0002: should have access to an external fixture (main.having a different precondition)
      should have access to an external fixture ... ok
in StartLayerTeardownTest. Layer : having a different precondition:layer. Test : test 0002: should have access to an external fixture (main.having a different precondition)
in StopLayerTeardownTest. Layer : having a different precondition:layer. Test : test 0002: should have access to an external fixture (main.having a different precondition)
in StartLayerSetup. Layer : having a case inside the external fixture:layer.
in StopLayerSetup. Layer : having a case inside the external fixture:layer.
in StartLayerSetupTest. Layer : having a case inside the external fixture:layer. Test : test 0000: should still have access to that fixture (main.having a case inside the external fixture)
in StopLayerSetupTest. Layer : having a case inside the external fixture:layer. Test : test 0000: should still have access to that fixture (main.having a case inside the external fixture)
      having a case inside the external fixture
        should still have access to that fixture ... ok
in StartLayerTeardownTest. Layer : having a case inside the external fixture:layer. Test : test 0000: should still have access to that fixture (main.having a case inside the external fixture)
in StopLayerTeardownTest. Layer : having a case inside the external fixture:layer. Test : test 0000: should still have access to that fixture (main.having a case inside the external fixture)
in StartLayerTeardown. Layer : having a case inside the external fixture:layer.
in StopLayerTeardown. Layer : having a case inside the external fixture:layer.
in StartLayerTeardown. Layer : having a different precondition:layer.
in StopLayerTeardown. Layer : having a different precondition:layer.
in StartLayerTeardown. Layer : having an expensive fixture:layer.
in StopLayerTeardown. Layer : having an expensive fixture:layer.
in StartLayerTeardown. Layer : SomeLayer.
in StopLayerTeardown. Layer : SomeLayer.

----------------------------------------------------------------------
Ran 8 tests in 0.007s

OK
```