### PR TITLE
Collect import time code coverage data 

### DIFF
--- a/nose2/events.py
+++ b/nose2/events.py
@@ -270,7 +270,7 @@ class PluginInterface(object):
         'reportSuccess', 'reportExpectedFailure', 'reportUnexpectedSuccess',
         'reportOtherOutcome', 'outcomeDetail', 'beforeErrorList',
         'beforeSummaryReport', 'afterSummaryReport', 'beforeInteraction',
-        'afterInteraction', 'createTests', 'afterTestRun',
+        'afterInteraction', 'createTests', 'createdTestSuite', 'afterTestRun',
         'moduleLoadedSuite', 'handleDir',
         # ... etc?
     )
@@ -1132,3 +1132,21 @@ class CreateTestsEvent(Event):
         self.testNames = testNames
         self.module = module
         super(CreateTestsEvent, self).__init__(**kw)
+
+
+class CreatedTestSuiteEvent(Event):
+    """Event fired after test loading.
+
+    Plugins can replace the loaded test suite by returning a test suite and
+    setting ``handled`` on this event.
+
+    .. attribute :: suite
+
+       Test Suite instance
+
+    """
+    _attrs = Event._attrs + ('suite', )
+
+    def __init__(self, suite, **kw):
+        self.suite = suite
+        super(CreatedTestSuiteEvent, self).__init__(**kw)

--- a/nose2/main.py
+++ b/nose2/main.py
@@ -251,11 +251,17 @@ class PluggableTestProgram(unittest.TestProgram):
             self.testLoader, self.testNames, self.module)
         result = self.session.hooks.createTests(event)
         if event.handled:
-            self.test = result
+            test = result
         else:
             log.debug("Create tests from %s/%s", self.testNames, self.module)
-            self.test = self.testLoader.loadTestsFromNames(
+            test = self.testLoader.loadTestsFromNames(
                 self.testNames, self.module)
+
+        event = events.CreatedTestSuiteEvent(test)
+        result = self.session.hooks.createdTestSuite(event)
+        if event.handled:
+            test = result
+        self.test = test
 
     def runTests(self):
         """Run tests"""


### PR DESCRIPTION
As discussed in #81, I've changed the coverage start hook to be earlier, and added a new-post-test-load event to pause coverage until the tests start.