### PR TITLE
Restore exception context when passed in loader's _makeFailedTest method

### DIFF
--- a/nose2/loader.py
+++ b/nose2/loader.py
@@ -7,6 +7,8 @@
 import logging
 import traceback
 
+import six
+
 from nose2 import events
 from nose2.compat import unittest
 
@@ -114,7 +116,11 @@ class PluggableTestLoader(object):
 
     def _makeFailedTest(self, classname, methodname, exception):
         def testFailure(self):
-            raise exception
+            if isinstance(exception, Exception):
+                raise exception
+            else:
+                # exception tuple (type, value, traceback)
+                six.reraise(*exception)
         attrs = {methodname: testFailure}
         TestClass = type(classname, (unittest.TestCase,), attrs)
         return self.suiteClass((TestClass(methodname),))

--- a/nose2/tests/unit/test_loader.py
+++ b/nose2/tests/unit/test_loader.py
@@ -8,6 +8,21 @@ class TestPluggableTestLoader(TestCase):
         self.session = session.Session()
         self.loader = loader.PluggableTestLoader(self.session)
 
+    def test_failed_load_tests_exception(self):
+        suite = self.loader.failedLoadTests('test', RuntimeError('err'))
+        tc = suite._tests[0]
+        with self.assertRaises(RuntimeError) as cm:
+            tc.test()
+        self.assertEqual(cm.exception.args, ('err', ))
+
+    def test_failed_load_tests_exc_info(self):
+        suite = self.loader.failedLoadTests(
+            'test', (RuntimeError, RuntimeError('err'), None))
+        tc = suite._tests[0]
+        with self.assertRaises(RuntimeError) as cm:
+            tc.test()
+        self.assertEqual(cm.exception.args, ('err', ))
+
     def test_load_from_module_calls_hook(self):
         self.session.hooks.register('loadTestsFromModule', FakePlugin())
         evt = events.LoadFromModuleEvent(self.loader, 'some_module')


### PR DESCRIPTION
Closes #48.