### PR TITLE
Fix collect plugin for Layers

### DIFF
--- a/nose2/plugins/collect.py
+++ b/nose2/plugins/collect.py
@@ -36,7 +36,7 @@ class CollectOnly(Plugin):
     def collectTests(self, suite, result):
         """Collect tests, but don't run them"""
         for test in suite:
-            if isinstance(test, unittest.TestSuite):
+            if isinstance(test, unittest.BaseTestSuite):
                 self.collectTests(test, result)
                 continue
             result.startTest(test)


### PR DESCRIPTION
Problem:
        the collect plugin does not work with LayerSuite instances
        because they are not instances of unittest.TestSuite but
        unittest.BaseTestSuite.

Solution:
        in the collect plugin, check that suites are instances of
        unittest.BaseTestSuite.