### PR TITLE
Fix "TypeError: exceptions must derive from BaseException" in loader error handling.

### DIFF
--- a/nose2/plugins/loader/generators.py
+++ b/nose2/plugins/loader/generators.py
@@ -182,12 +182,11 @@ class Generators(Plugin):
                 method = functools.update_wrapper(method, func)
                 setattr(instance, method_name, method)
                 yield instance
-        except:
-            exc_info = sys.exc_info()
+        except Exception as e:
             test_name = '%s.%s.%s' % (testCaseClass.__module__,
                                       testCaseClass.__name__,
                                       name)
-            yield event.loader.failedLoadTests(test_name, exc_info)
+            yield event.loader.failedLoadTests(test_name, e)
 
     def _testsFromGeneratorFunc(self, event, obj):
         extras = list(obj())


### PR DESCRIPTION
Passing on `sys.exc_info()` results in an error in `PluggableTestLoader._makeFailedTest` because tuple is not a subclass of `BaseException`.