### PR TITLE
refactor layers

### DIFF
--- a/nose2/exceptions.py
+++ b/nose2/exceptions.py
@@ -8,3 +8,8 @@ __unittest = True
 class TestNotFoundError(Exception):
 
     """Raised when a named test cannot be found"""
+
+
+class LoadTestsFailure(Exception):
+
+    """Raised when a test cannot be loaded"""

--- a/nose2/plugins/layers.py
+++ b/nose2/plugins/layers.py
@@ -3,9 +3,9 @@ import re
 
 import six
 
-from nose2 import events, util
+from nose2 import events, util, exceptions
 from nose2.suite import LayerSuite
-from nose2.compat import unittest, OrderedDict
+from nose2.compat import OrderedDict
 
 BRIGHT = r'\033[1m'
 RESET = r'\033[0m'
@@ -15,95 +15,171 @@ __unittest = True
 log = logging.getLogger(__name__)
 
 
+class MissingParentLayer(Exception):
+    pass
+
+
 class Layers(events.Plugin):
     alwaysOn = True
 
     def startTestRun(self, event):
-        event.suite = self._makeLayerSuite(event)
-
-    def _makeLayerSuite(self, event):
-        return self._sortByLayers(
+        event.suite = self.make_suite(
             event.suite, self.session.testLoader.suiteClass)
 
-    def _sortByLayers(self, suite, suiteClass):
-        top = suiteClass()
-        # first find all of the layers mentioned
-        layers = OrderedDict()
-        for test in self._flatten(suite):
-            # split tests up into buckets by layer
+    @classmethod
+    def get_layers_from_suite(cls, suite, suiteClass):
+        top_layer = suiteClass()
+        layers_dict = OrderedDict()
+        for test in cls.flatten_suite(suite):
             layer = getattr(test, 'layer', None)
             if layer:
-                layers.setdefault(layer, LayerSuite(layer=layer)).addTest(test)
+                if layer not in layers_dict:
+                    layers_dict[layer] = LayerSuite(layer=layer)
+                layers_dict[layer].addTest(test)
             else:
-                top.addTest(test)
+                top_layer.addTest(test)
+        cls.get_parent_layers(layers_dict)
+        return top_layer, layers_dict
 
-        # then organize layers into a tree
-        remaining = list(layers.keys())
-        seen = set()
+    @classmethod
+    def get_parent_layers(cls, layers_dict):
+        for layer in layers_dict.keys():
+            for parent in layer.__bases__:
+                if parent is object:
+                    continue
+                if parent not in layers_dict:
+                    layers_dict[parent] = LayerSuite(layer=parent)
+                    cls.get_parent_layers(layers_dict)
+
+    def make_suite(cls, suite, suiteClass):
+        top_layer, layers_dict = cls.get_layers_from_suite(suite, suiteClass)
         tree = {}
-        while remaining:
-            ly = remaining.pop()
-            if ly in seen:
+        unresolved_layers = cls.update_layer_tree(tree, layers_dict.keys())
+        while unresolved_layers:
+            remaining = cls.update_layer_tree(tree, unresolved_layers)
+            if len(remaining) == len(unresolved_layers):
+                raise exceptions.LoadTestsFailure(
+                    'Could not resolve layer dependencies')
+            unresolved_layers = remaining
+        for layer in tree.keys():
+            if layer and layer not in layers_dict:
+                layers_dict[layer] = LayerSuite(layer=layer)
+        cls.tree_to_suite(tree, None, top_layer, layers_dict)
+        return top_layer
+
+    @classmethod
+    def update_layer_tree(cls, tree, layers):
+        remaining = []
+        for layer in layers:
+            try:
+                cls.add_layer_to_tree(tree, layer)
+            except MissingParentLayer:
+                remaining.append(layer)
+        return remaining
+
+    @classmethod
+    def insert_mixins(cls, tree, layer, outer):
+        mixins = getattr(layer, 'mixins', None)
+        if not mixins:
+            return outer
+        last = outer
+        for mixin in mixins:
+            mixin_ancestor = cls.get_oldest_parent(mixin)
+            if last is None:
+                tree.setdefault(None, []).append(mixin_ancestor)
+            else:
+                # The mixin_ancestor can be a layer that has been added to the
+                # tree already. If so, it should a base layer, since it's the
+                # last ancestor. We need to remove it from there, and insert it
+                # in the "last" layer.
+                if mixin_ancestor in tree[None]:
+                    tree[None].remove(mixin_ancestor)
+                tree[last].append(mixin_ancestor)
+                if mixin_ancestor not in tree:
+                    tree[mixin_ancestor] = []
+            if mixin not in tree:
+                tree[mixin] = []
+            last = mixin
+        return last
+
+    @classmethod
+    def insert_layer(cls, tree, layer, outer):
+        if outer is object:
+            outer = cls.insert_mixins(tree, layer, None)
+        elif outer in tree:
+            outer = cls.insert_mixins(tree, layer, outer)
+        else:
+            err = '{0} not found in {1}'.format(outer, tree)
+            raise exceptions.LoadTestsFailure(err)
+        if outer is None:
+            tree.setdefault(None, []).append(layer)
+        else:
+            tree[outer].append(layer)
+        tree[layer] = []
+
+    @staticmethod
+    def get_parents_from_tree(layer, tree):
+        parents = []
+        for key, value in tree.items():
+            if layer in value:
+                parents.append(key)
+
+    @classmethod
+    def get_oldest_parent(cls, layer):
+        # FIXME: we assume that there is only one oldest parent
+        # it should be the case most of the time but it will break sometimes.
+        oldest = True
+        for parent in layer.__bases__:
+            if parent in [None, object]:
                 continue
-            seen.add(ly)
-            # superclasses of this layer
-            if ly is None:
-                deps = []
             else:
-                deps = [cls for cls in util.bases_and_mixins(ly)
-                        if cls is not object]
-                deps.reverse()
-            if not deps:
-                # layer is top-level
-                self._addToTree(tree, ly, None)
-            else:
-                outer = ly
-                while deps:
-                    inner, outer = outer, deps.pop()
-                    self._addToTree(tree, inner, outer)
-                    if outer not in layers:
-                        remaining.append(outer)
-                        layers[outer] = LayerSuite(layer=outer)
+                oldest = False
+                return cls.get_oldest_parent(parent)
+        if oldest:
+            return layer
 
-        # finally build the top-level suite
-        self._treeToSuite(tree, None, top, layers)
-        # printtree(top)
-        return top
+    @classmethod
+    def add_layer_to_tree(cls, tree, layer):
+        parents = layer.__bases__
+        if not parents:
+            err = 'Invalid layer {0}: should at least inherit from `object`'
+            raise exceptions.LoadTestsFailure(err.format(layer))
+        for parent in parents:
+            if parent not in tree and parent is not object:
+                raise MissingParentLayer()
+        # if we reached that point, then all the parents are in the tree
+        # if there are multiple parents, we first try to get the closest
+        # to the current layer.
+        for parent in parents:
+            if not cls.get_parents_from_tree(parent, tree):
+                cls.insert_layer(tree, layer, parent)
+                return
+        raise exceptions.LoadTestsFailure('Failed to add {0}'.format(layer))
 
-    def _addToTree(self, tree, inner, outer):
-        found = False
-        for k, v in tree.items():
-            if inner in v:
-                found = True
-                if outer is not None:
-                    v.remove(inner)
-                break
-        if outer is not None or not found:
-            tree.setdefault(outer, []).append(inner)
-
-    def _treeToSuite(self, tree, key, suite, layers):
-        mysuite = layers.get(key, None)
-        if mysuite:
-            suite.addTest(mysuite)
-            suite = mysuite
+    @classmethod
+    def tree_to_suite(cls, tree, key, suite, layers):
+        _suite = layers.get(key, None)
+        if _suite:
+            suite.addTest(_suite)
+            suite = _suite
         sublayers = tree.get(key, [])
         # ensure that layers with a set order are in order
-        sublayers.sort(key=self._sortKey)
-        log.debug('sorted sublayers of %s (%s): %s', mysuite,
-                  getattr(mysuite, 'layer', 'no layer'), sublayers)
+        sublayers.sort(key=cls.get_layer_position)
         for layer in sublayers:
-            self._treeToSuite(tree, layer, suite, layers)
+            cls.tree_to_suite(tree, layer, suite, layers)
 
-    def _flatten(self, suite):
+    @classmethod
+    def flatten_suite(cls, suite):
         out = []
         for test in suite:
             try:
-                out.extend(self._flatten(test))
+                out.extend(cls.flatten_suite(test))
             except TypeError:
                 out.append(test)
         return out
 
-    def _sortKey(self, layer):
+    @staticmethod
+    def get_layer_position(layer):
         pos = getattr(layer, 'position', None)
         # ... lame
         if pos is not None:
@@ -169,11 +245,12 @@ class LayerReporter(events.Plugin):
 
 
 # for debugging
-def printtree(suite, indent=''):
-    six.print_('%s%s ->' % (indent, getattr(suite, 'layer', 'no layer')))
-    for test in suite:
-        if isinstance(test, unittest.BaseTestSuite):
-            printtree(test, indent + '  ')
-        else:
-            six.print_('%s %s' % (indent, test))
-    six.print_('%s<- %s' % (indent, getattr(suite, 'layer', 'no layer')))
+# def printtree(suite, indent=''):
+#     from nose2.compat import unittest
+#     six.print_('%s%s ->' % (indent, getattr(suite, 'layer', 'no layer')))
+#     for test in suite:
+#         if isinstance(test, unittest.BaseTestSuite):
+#             printtree(test, indent + '  ')
+#         else:
+#             six.print_('%s %s' % (indent, test))
+#     six.print_('%s<- %s' % (indent, getattr(suite, 'layer', 'no layer')))

--- a/nose2/tests/functional/support/such/test_such_timing.py
+++ b/nose2/tests/functional/support/such/test_such_timing.py
@@ -1,0 +1,50 @@
+import time
+from nose2.tools import such
+
+
+def slow_blocking_init():
+    print("YEAH2")
+    time.sleep(1)
+    print("a second elapsed")
+    time.sleep(1)
+    print("a second elapsed")
+    return True
+
+
+class Layer1(object):
+
+    description = "Layer1 description"
+
+    @classmethod
+    def setUp(cls):
+        print("YEAH")
+        it.obj = False
+
+
+class Layer2(object):
+
+    description = "Layer2 description"
+
+    @classmethod
+    def setUp(cls):
+        it.obj = slow_blocking_init()
+
+
+with such.A('system with a fast initial setup layer') as it:
+
+    it.uses(Layer1)
+
+    @it.should('not have obj initialized')
+    def test():
+        assert not it.obj
+
+
+    with it.having('a second slow setup layer'):
+
+        it.uses(Layer2)
+
+        @it.should('have obj initialized')
+        def test():
+            assert it.obj
+
+it.createTests(globals())

--- a/nose2/tests/functional/test_such_dsl.py
+++ b/nose2/tests/functional/test_such_dsl.py
@@ -109,3 +109,10 @@ class TestSuchDSL(FunctionalTestCase):
         self.assertTestRunOutputMatches(proc, stderr='Ran 2 tests in')
         self.assertTestRunOutputMatches(proc, stderr='OK')
 
+    def test_long_setup(self):
+        proc = self.runIn('such',
+                          '-v',
+                          '--plugin=nose2.plugins.layers',
+                          'test_such_timing')
+        self.assertTestRunOutputMatches(proc, stderr=r'Ran 2 tests in')
+        self.assertTestRunOutputMatches(proc, stderr='OK')

--- a/nose2/tests/unit/test_layers_plugin.py
+++ b/nose2/tests/unit/test_layers_plugin.py
@@ -221,6 +221,62 @@ class TestLayers(TestCase):
                    ['test (nose2.tests.unit.test_layers_plugin.T4)', ]]]
         self.assertEqual(self.names(event.suite), expect)
 
+    def test_mixin_in_top_layer(self):
+
+        class M1(object):
+            pass
+
+        class L1(object):
+            mixins = (M1,)
+
+        class T1(unittest.TestCase):
+            layer = L1
+
+            def test(self):
+                pass
+
+        suite = unittest.TestSuite([T1('test')])
+        event = events.StartTestRunEvent(None, suite, None, 0, None)
+        self.plugin.startTestRun(event)
+        expect = [  # M1
+                  [  # L1
+                   [  # T1
+                    'test (nose2.tests.unit.test_layers_plugin.T1)']]]
+        self.assertEqual(self.names(event.suite), expect)
+
+    def test_mixin_in_inner_layer(self):
+
+        class M1(object):
+            pass
+
+        class L1(object):
+            pass
+
+        class L2(L1):
+            mixins = (M1,)
+
+        class T1(unittest.TestCase):
+            layer = L1
+
+            def test(self):
+                pass
+
+        class T2(unittest.TestCase):
+            layer = L2
+
+            def test(self):
+                pass
+
+        suite = unittest.TestSuite([T1('test'), T2('test')])
+        event = events.StartTestRunEvent(None, suite, None, 0, None)
+        self.plugin.startTestRun(event)
+        expect = [  # L1
+                  ['test (nose2.tests.unit.test_layers_plugin.T1)',
+                   # M1
+                   [  # L2
+                    ['test (nose2.tests.unit.test_layers_plugin.T2)']]]]
+        self.assertEqual(self.names(event.suite), expect)
+
     def test_mixin_inheritance(self):
         # without mixin
         # L1


### PR DESCRIPTION
This is an attempt to fix https://github.com/nose-devs/nose2/issues/215

The problem is that when sorting the layers, we treat layer mixins and layer parents the same way. Mixins cannot be treated like regular layers, because they don't always have parents. Instead, mixins should be inserted between the layer the parent layer and the layers they belong to, whatever their parents are.

To take the example given in the issue, here is how layers are currently resolved:
```
no layer ->
  <class 'test_such_timing.Layer1'> ->
    <class 'test_such_timing.A system with a fast initial setup layer:layer'> ->
     test 0000: should not have obj initialized (test_such_timing.A system with a fast initial setup layer)
      <class 'test_such_timing.having a second slow setup layer:layer'> ->
       test 0000: should have obj initialized (test_such_timing.having a second slow setup layer)
      <- <class 'test_such_timing.having a second slow setup layer:layer'>
    <- <class 'test_such_timing.A system with a fast initial setup layer:layer'>
  <- <class 'test_such_timing.Layer1'>
  <class 'test_such_timing.Layer2'> ->
  <- <class 'test_such_timing.Layer2'>
<- no layer
```

`Layer2` is a mixin of the `having a second slow setup` layer, so it should enclose this layer. It does not because since it has no parent layer, the current algorithm to sort layers considers it is a base layer.

With this PR layers are sorted like this:

```
no layer ->
  <class 'test_such_timing.Layer1'> ->
    <class 'test_such_timing.A system with a fast initial setup layer:layer'> ->
     test 0000: should not have obj initialized (test_such_timing.A system with a fast initial setup layer)
      <class 'test_such_timing.Layer2'> ->
        <class 'test_such_timing.having a second slow setup layer:layer'> ->
         test 0000: should have obj initialized (test_such_timing.having a second slow setup layer)
        <- <class 'test_such_timing.having a second slow setup layer:layer'>
      <- <class 'test_such_timing.Layer2'>
    <- <class 'test_such_timing.A system with a fast initial setup layer:layer'>
  <- <class 'test_such_timing.Layer1'>
<- no layer
```

One unit-test still fails, but this is because it basically verifies the problematic behavior.

There is still work to do (adding tests, splitting this into several smaller commits, etc), but if anyone has feedback about this, I'd like to hear. @jpellerin I'd be interested in your opinion, since you seem to be the main architect of this layers feature (btw, thanks for all the super detailled unit and functional tests).