### PR TITLE
fix #213

### DIFF
--- a/nose2/suite.py
+++ b/nose2/suite.py
@@ -22,6 +22,7 @@ class LayerSuite(unittest.BaseTestSuite):
         self.wasSetup = False
 
     def run(self, result):
+        self.handle_previous_test_teardown(result)
         if not self._safeMethodCall(self.setUp, result):
             return
         try:
@@ -36,6 +37,21 @@ class LayerSuite(unittest.BaseTestSuite):
         finally:
             if self.wasSetup:
                 self._safeMethodCall(self.tearDown, result)
+
+    def handle_previous_test_teardown(self, result):
+        try:
+            prev = result._previousTestClass
+        except AttributeError:
+            return
+        layer_attr = getattr(prev, 'layer', None)
+        if isinstance(layer_attr, LayerSuite):
+            return
+        try:
+            suite_obj = unittest.suite.TestSuite()
+            suite_obj._tearDownPreviousClass(None, result)
+            suite_obj._handleModuleTearDown(result)
+        finally:
+            delattr(result, '_previousTestClass')
 
     def setUp(self):
         if self.layer is None:

--- a/nose2/tests/functional/support/scenario/layers_and_non_layers/common.py
+++ b/nose2/tests/functional/support/scenario/layers_and_non_layers/common.py
@@ -1,0 +1,60 @@
+import unittest
+import logging
+log = logging.getLogger(__name__)
+
+
+class UniqueResource(object):
+    _instance = None
+    used = False
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super(UniqueResource, cls).__new__(
+                cls, *args, **kwargs)
+        return cls._instance
+
+    def lock(self):
+        if not self.used:
+            self.used = True
+        else:
+            raise Exception("Resource allready used")
+
+    def unlock(self):
+        if self.used:
+            self.used = False
+        else:
+            raise Exception("Resource already unlocked")
+
+
+class NormalTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        log.info("Called setUpClass in NormalTest")
+        cls.unique_resource = UniqueResource()
+        cls.unique_resource.lock()
+
+    @classmethod
+    def tearDownClass(cls):
+        log.info("Called tearDownClass in NormalTest")
+        cls.unique_resource.unlock()
+
+    def test(self):
+        self.assertTrue(self.unique_resource.used)
+
+
+class NormalTestTwo(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        log.info("Called setUpClass in NormalTestTwo")
+        cls.unique_resource = UniqueResource()
+        cls.unique_resource.lock()
+
+    @classmethod
+    def tearDownClass(cls):
+        log.info("Called tearDownClass in NormalTestTwo")
+        cls.unique_resource.unlock()
+
+    def test(self):
+        self.assertTrue(self.unique_resource.used)

--- a/nose2/tests/functional/support/scenario/layers_and_non_layers/test_layers.py
+++ b/nose2/tests/functional/support/scenario/layers_and_non_layers/test_layers.py
@@ -1,0 +1,67 @@
+import unittest
+import logging
+from .common import UniqueResource, NormalTest, NormalTestTwo
+log = logging.getLogger(__name__)
+
+
+class Layer1(object):
+
+    @classmethod
+    def setUp(cls):
+        log.info("Called setup in layer 1")
+        cls.unique_resource = UniqueResource()
+        cls.unique_resource.lock()
+
+    @classmethod
+    def tearDown(cls):
+        log.info("Called teardown in layer 2")
+        cls.unique_resource.unlock()
+
+
+class Layer2(object):
+
+    @classmethod
+    def setUp(cls):
+        log.info("Called setup in layer 2")
+        cls.unique_resource = UniqueResource()
+        cls.unique_resource.lock()
+
+    @classmethod
+    def tearDown(cls):
+        log.info("Called teardown in layer 2")
+        cls.unique_resource.unlock()
+
+
+class Layer3(Layer2):
+
+    @classmethod
+    def setUp(cls):
+        log.info("Called setup in layer 3")
+
+    @classmethod
+    def tearDown(cls):
+        log.info("Called teardown in layer 3")
+
+
+class LayerTest1(unittest.TestCase):
+
+    layer = Layer1
+
+    def test(self):
+        self.assertTrue(self.layer.unique_resource.used)
+
+
+class LayerTest2(unittest.TestCase):
+
+    layer = Layer2
+
+    def test(self):
+        self.assertTrue(self.layer.unique_resource.used)
+
+
+class LayerTest3(unittest.TestCase):
+
+    layer = Layer2
+
+    def test(self):
+        self.assertTrue(self.layer.unique_resource.used)

--- a/nose2/tests/functional/support/scenario/layers_and_non_layers/test_such_with_has_setup.py
+++ b/nose2/tests/functional/support/scenario/layers_and_non_layers/test_such_with_has_setup.py
@@ -1,0 +1,24 @@
+from nose2.tools import such
+import logging
+from .common import UniqueResource, NormalTest, NormalTestTwo
+log = logging.getLogger(__name__)
+
+
+with such.A('system with setup') as it:
+
+    @it.has_setup
+    def setup():
+        log.info("Called setup in such test")
+        it.unique_resource = UniqueResource()
+        it.unique_resource.lock()
+
+    @it.has_teardown
+    def teardown():
+        log.info("Called teardown in such test")
+        it.unique_resource.unlock()
+
+    @it.should('do something')
+    def test(case):
+        it.assertTrue(it.unique_resource.used)
+
+it.createTests(globals())

--- a/nose2/tests/functional/support/scenario/layers_and_non_layers/test_such_with_uses_decorator.py
+++ b/nose2/tests/functional/support/scenario/layers_and_non_layers/test_such_with_uses_decorator.py
@@ -1,0 +1,51 @@
+from nose2.tools import such
+import logging
+from .common import UniqueResource, NormalTest, NormalTestTwo
+log = logging.getLogger(__name__)
+
+
+class Layer1(object):
+
+    description = 'Layer1'
+
+    @classmethod
+    def setUp(cls):
+        log.info("Called setup in layer 1")
+        it.unique_resource = UniqueResource()
+        it.unique_resource.lock()
+
+    @classmethod
+    def tearDown(cls):
+        log.info("Called teardown in layer 2")
+        it.unique_resource.unlock()
+
+
+class Layer2(object):
+
+    description = 'Layer2'
+
+    @classmethod
+    def setUp(cls):
+        log.info("Called setup in layer 2")
+
+    @classmethod
+    def tearDown(cls):
+        log.info("Called teardown in layer 2")
+
+with such.A('system with setup') as it:
+
+    it.uses(Layer1)
+
+    @it.should('do something')
+    def test(case):
+        it.assertTrue(it.unique_resource.used)
+
+    with it.having('another setup'):
+
+        it.uses(Layer2)
+
+        @it.should('do something else')
+        def test(case):
+            it.assertTrue(it.unique_resource.used)
+
+it.createTests(globals())

--- a/nose2/tests/functional/test_layers_plugin.py
+++ b/nose2/tests/functional/test_layers_plugin.py
@@ -120,3 +120,14 @@ Base
         self.assertTestRunOutputMatches(proc, stderr='ERROR: LayerSuite')
         self.assertTestRunOutputMatches(proc, stderr='FAIL')
         self.assertTestRunOutputMatches(proc, stderr='Bad Error in Layer setUp!')
+
+    def test_layers_and_non_layers(self):
+        proc = self.runIn(
+            'scenario/',
+            'layers_and_non_layers',
+            '-v',
+            '--plugin=nose2.plugins.layers',
+            )
+        self.assertTestRunOutputMatches(proc, stderr='Ran 12 tests in')
+        self.assertTestRunOutputMatches(proc, stderr='OK')
+        self.assertEqual(proc.poll(), 0)


### PR DESCRIPTION
attempts to fix https://github.com/nose-devs/nose2/issues/213

Here is a simplified version of the `TestSuite.run` in `unittest`:
```python
    def run(self, result, debug=False):
        topLevel = False
        if getattr(result, '_testRunEntered', False) is False:
            # result._testRunEntered set to `True` when we start running the suite
            result._testRunEntered = topLevel = True

        # we iterate over the tests with the following logic:
        #      - for each test
        #          - check if it a suite:
        #               - yes => run the suite
        #               - no => check if it belongs to the same class than the previous class:
        #                     - yes => run the test
        #                     - no => run tearDown of previous class, run setup for current class, run the test
        for index, test in enumerate(self):

            if _isnotsuite(test):
                self._tearDownPreviousClass(test, result)
                self._handleModuleFixture(test, result)
                self._handleClassSetUp(test, result)
                result._previousTestClass = test.__class__

                if (getattr(test.__class__, '_classSetupFailed', False) or
                    getattr(result, '_moduleSetUpFailed', False)):
                    continue

            test(result)

        if topLevel:
            self._tearDownPreviousClass(None, result)
            self._handleModuleTearDown(result)
        return result
```

in the example given in the issue the suite looks like this:
```
<unittest2.suite.TestSuite tests=[
                <test_normal.NormalTest testMethod=test>,
                <test_normal.NormalTestTwo testMethod=test>,
                <nose2.suite.LayerSuite tests=[
                             <test_such.A system with setup testMethod=test 0000: should do something>
                ]>
]>
```

So what happens is that at the 3rd iteration, `test` is `<nose2.suite.LayerSuite tests=[<test_such.A system with setup testMethod=test 0000: should do something>]>`, which is a suite. Hence, the teardown is _not_ run.

The solution is to add logic in `nose2.suite.LayerSuite` to handle the previous test teardown, if the test class is not part of a layer. To determine if a test class is part of a layer or not, we check for a `layer` attribute, and if its value is an instance of a `LayerSuite`. The thing is I'm not sure the value will always be an instance of `LayerSuite`, so I need to make more tests.