### PR TITLE
test attributes -E option: make builtins available

### DIFF
--- a/nose2/plugins/attrib.py
+++ b/nose2/plugins/attrib.py
@@ -1,3 +1,4 @@
+import sys
 import logging
 from unittest import TestSuite
 
@@ -143,6 +144,11 @@ def _get_attr(test, key):
             val = getattr(meth, key, undefined)
             if val is not undefined:
                 return val
+    if sys.version_info >= (3, 0):
+        import builtins
+    else:
+        builtins = __import__('__builtin__')
+    return getattr(builtins, key, None)
 
 
 class ContextHelper:


### PR DESCRIPTION
Makes querying by test attributes easier:

``` python
def test(self):
    pass
test.flags = 'red', 'green', 'blue'
```

The above test can be executed with

```
python -m nose2 -E 'set(flags) >= {"green", "blue"}'
```
