### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,4 +45,4 @@ plugins branch, and overrides various unittest2 objects.
 You are witnesses at the new birth of nose, mark 2. Hope you enjoy our
 new direction!
 
-.. _differences: http://readthedocs.org/docs/nose2/en/latest/differences.html
+.. _differences: https://nose2.readthedocs.io/en/latest/differences.html


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.