### PR TITLE
Allow setting the pdb module from the cmdline.

### DIFF
--- a/nose2/tests/unit/test_debugger_plugin.py
+++ b/nose2/tests/unit/test_debugger_plugin.py
@@ -11,15 +11,23 @@ class NullHandler(logging.Handler):
         pass
 
 
-class StubPdb(object):
+class StubPdbModule(object):
 
     def __init__(self):
+
         self.called = False
         self.tb = None
 
-    def post_mortem(self, tb):
-        self.called = True
-        self.tb = tb
+        class Pdb(object):
+
+            def reset(_):
+                pass
+
+            def interaction(_, frame, tb):
+                self.called = True
+                self.tb = tb
+
+        self.Pdb = Pdb
 
 
 class NoInteraction(events.Plugin):
@@ -50,7 +58,7 @@ class TestDebugger(TestCase):
         self.case = Test
 
         self.pdb = self.plugin.pdb
-        self.plugin.pdb = StubPdb()
+        self.plugin.pdb = StubPdbModule()
 
         self.plugin.register()
 


### PR DESCRIPTION
e.g. `nose2 -D --pdbmodule=IPython.core.debugger`.  This should make
plugins such as nose-ipdb obsolete.

The module passed as argument should define a class named `Pdb`.
