### PR TITLE
Support unittest2 installed on Python 2.7

### DIFF
--- a/nose2/util.py
+++ b/nose2/util.py
@@ -236,16 +236,16 @@ def has_module_fixtures(test):
 def has_class_fixtures(test):
     # hasattr would be the obvious thing to use here. Unfortunately, all tests
     # inherit from unittest2.case.TestCase, and that *always* has setUpClass and
-    # tearDownClass methods. Thus, the following (ugly) solution:
-    ver = platform.python_version_tuple()
-    if float('{0}.{1}'.format(*ver[:2])) >= 2.7:
-        name = 'unittest.case'
-    else:
-        name = 'unittest2.case'
+    # tearDownClass methods. Thus, exclude the unitest and unittest2 base
+    # classes from the lookup.
+    def is_not_base_class(c):
+        return (
+            "unittest.case" not in c.__module__ and
+            "unittest2.case" not in c.__module__)
     has_class_setups = any(
-        'setUpClass' in c.__dict__ for c in test.__class__.__mro__ if c.__module__.find(name) == -1)
+        'setUpClass' in c.__dict__ for c in test.__class__.__mro__ if is_not_base_class(c))
     has_class_teardowns = any(
-        'tearDownClass' in c.__dict__ for c in test.__class__.__mro__ if c.__module__.find(name) == -1)
+        'tearDownClass' in c.__dict__ for c in test.__class__.__mro__ if is_not_base_class(c))
     return has_class_setups or has_class_teardowns
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands=unit2 discover []
 [testenv:docs]
 basepython=python2.7
 changedir=docs
-deps=-r{toxinidir}/requirements.txt
+deps=-r{toxinidir}/requirements-2.7.txt
      -r{toxinidir}/requirements-docs.txt
 commands=sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
@@ -23,16 +23,19 @@ deps=-r{toxinidir}/requirements.txt
      -r{toxinidir}/requirements-py26.txt
 commands=unit2 discover []
 
+[testenv:py27]
+deps=-r{toxinidir}/requirements-2.7.txt
+
 [testenv:self27]
 basepython=python2.7
-deps=-r{toxinidir}/requirements.txt
+deps=-r{toxinidir}/requirements-2.7.txt
 setenv=PYTHONPATH={toxinidir}
 commands=python -m nose2.__main__ []
 
 [testenv:cov27]
 basepython=python2.7
 deps=coverage>=3.3
-     -r{toxinidir}/requirements.txt
+     -r{toxinidir}/requirements-2.7.txt
 commands=coverage erase
          coverage run -m unittest discover []
          coverage report --include=*nose2* --omit=*nose2/tests*


### PR DESCRIPTION
If unittest2 is installed on Python 2.7, the detection of setUp and tearDown classes fail, which lead to multiprocessing-based generator test failures (`nose2.tests.functional.test_mp_plugin.MPPluginTestRuns.test_large_number_of_tests_stresstest` and `nose2.tests.functional.test_mp_plugin.MPPluginTestRuns.test_socket_stresstest`)

This pull request also contains a commit to enable the Python2.7-specific requirements file in `tox.ini`.
