### PR TITLE
Add config section cacheing on first access, plus test of same

### DIFF
--- a/nose2/session.py
+++ b/nose2/session.py
@@ -87,6 +87,7 @@ class Session(object):
         self.testResult = None
         self.testLoader = None
         self.logLevel = logging.WARN
+        self.configCache = dict()
 
     def get(self, section):
         """Get a config section.
@@ -95,11 +96,17 @@ class Session(object):
         :returns: instance of self.configClass.
 
         """
-        # FIXME cache these
+        # If section exists in cache, return cached version
+        if section in self.configCache:
+            return self.configCache[section]
+
+        # If section doesn't exist in cache, parse config file
+        # (and cache result)
         items = []
         if self.config.has_section(section):
             items = self.config.items(section)
-        return self.configClass(items)
+        self.configCache[section] = self.configClass(items)
+        return self.configCache[section]
 
     def loadConfigFiles(self, *filenames):
         """Load config files.

--- a/nose2/tests/functional/test_session.py
+++ b/nose2/tests/functional/test_session.py
@@ -25,3 +25,33 @@ class SessionFunctionalTests(FunctionalTestCase):
         assert self.s.plugins
         plug = self.s.plugins[0]
         self.assertEqual(plug.a, 1)
+
+    def test_session_config_cacheing(self):
+        """Test cacheing of config sections works"""
+
+        # Create new session (generic one likely already cached
+        # depending on test order)
+        cachesess = session.Session()
+        cachesess.loadConfigFiles(support_file('cfg', 'a.cfg'))
+
+        # First access to given section, should read from config file
+        firstaccess = cachesess.get('a')
+        assert firstaccess.as_int("a") == 1
+
+        # Hack cached Config object internals to make the stored value
+        # something different
+        cachesess.configCache["a"]._mvd["a"] = "0"
+        newitems = []
+        for item in cachesess.configCache["a"]._items:
+            if item != ("a", "1"):
+                newitems.append(item)
+            else:
+                newitems.append(("a", "0"))
+        cachesess.configCache["a"]._items = newitems
+
+        # Second access to given section, confirm returns cached value
+        # rather than parsing config file again
+        secondaccess = cachesess.get("a")
+        assert secondaccess.as_int("a") == 0
+
+


### PR DESCRIPTION
The session object was parsing the config file anew every time the config information was accessed. There was a comment saying "FIXME" and I wanted to do something with a plugin extension that involved dynamically changing the config contents (which I couldn't do if they weren't actually stored between accesses), so I wrote this fix to cache the config section retrieved after each config file access.

It's a pretty simple change and someone presumably looked at this previously (hence the FIXME), so there may be a reason it wasn't done before! I can't see anything obvious though and the tests pass. 

Caveat: tested under python 2.7, I don't have tox set up because I did something a little odd with my nose2 installation. It's a straightforward change though and 2to3 doesn't spot anything, so I'm confident that if the tests pass under 2.7 they'll pass under everything else too.