### PR TITLE
Added ability to predefine layers of fixtures and tests, and inject them into other Scenarios

### DIFF
--- a/nose2/tests/functional/support/such/test_such.py
+++ b/nose2/tests/functional/support/such/test_such.py
@@ -13,6 +13,18 @@ class SomeLayer(object):
     def tearDown(cls):
         del it.somelayer
 
+
+#
+# Layers of test fixtures, tests, and other layers can be defined ahead of time
+# for later use in multiple places. They all also share the same attribute
+# namespace, so referencing `external.somelayer` will get you the same object
+# that `it.somelayer` references in the next Such Scenario.
+#
+with such.Layer('having a case inside the external fixture') as external:
+    @external.should('still have access to that fixture')
+    def test(case):
+        assert external.somelayer
+
 #
 # Such tests start with a declaration about the system under test
 # and will typically bind the test declaration to a variable with
@@ -142,10 +154,7 @@ with such.A('system with complex setup') as it:
             def test(case):
                 assert it.somelayer
 
-            with it.having('a case inside the external fixture'):
-                @it.should('still have access to that fixture')
-                def test(case):
-                    assert it.somelayer
+            it.uses(external)
 
 #
 # To convert the layer definitions into test cases, you have to call

--- a/nose2/tools/such.py
+++ b/nose2/tools/such.py
@@ -59,6 +59,10 @@ def Layer(description, desc_pre=None, desc_post=None):
       it.createTests(globals())
 
     """
+    if desc_pre is None:
+        desc_pre = ""
+    if desc_post is None:
+        desc_post = ""
     yield Scenario(
         description,
         desc_pre=desc_pre,

--- a/nose2/tools/such.py
+++ b/nose2/tools/such.py
@@ -257,6 +257,12 @@ class Scenario(object):
         else:
             setattr(self._helper, attr, value)
 
+    def __delattr__(self, attr):
+        if attr in self.__dict__.keys() or attr == "_group":
+            super(Scenario, self).__delattr__(attr)
+        else:
+            delattr(self._helper, attr)
+
     def createTests(self, mod):
         """Generate test cases for this scenario.
 

--- a/nose2/tools/such.py
+++ b/nose2/tools/such.py
@@ -31,6 +31,41 @@ def A(description):
     yield Scenario(description)
 
 
+@contextmanager
+def Layer(description, desc_pre=None, desc_post=None):
+    """Test scenario layer context manager.
+
+    This works exactly like ``such.A``, but the text before and after the
+    description can be customized, and both are blank by default. It is
+    primarily used to predefine a group of tests, fixtures, and sub-groups that
+    can be used repeatedly, anywhere you want it, including in other
+    :class:`nose2.tools.such.Scenario` instances made with this function, and
+    even in other modules.
+
+    Yields a :class:`nose2.tools.such.Scenario` instance with the desired
+    description beginning and ending text (both blank by default), which by
+    convention is not bound to ``it``, as it would cause a naming conflict
+    between itself and the :class:`nose2.tools.such.Scenario` instance that
+    will actually be used to create the tests.
+
+    .. code-block :: python
+
+      with such.Layer('Some Layer') as SomeLayer:
+          # tests and fixtures
+
+      with such.A('test scenario') as it:
+          it.uses(SomeLayer)
+
+      it.createTests(globals())
+
+    """
+    yield Scenario(
+        description,
+        desc_pre=desc_pre,
+        desc_post=desc_post,
+    )
+
+
 class Helper(unittest.TestCase):
 
     def runTest(self):
@@ -48,9 +83,15 @@ class Scenario(object):
     that depend on those fixtures.
     """
     _helper = helper
+    desc_pre = "A "
+    desc_post = ""
 
-    def __init__(self, description):
-        self._group = Group('A %s' % description, 0)
+    def __init__(self, description, desc_pre=None, desc_post=None):
+        if desc_pre is None:
+            desc_pre = self.desc_pre
+        if desc_post is None:
+            desc_post = self.desc_post
+        self._group = Group('%s%s%s' % (desc_pre, description, desc_post))
 
     @contextmanager
     def having(self, description):
@@ -74,8 +115,13 @@ class Scenario(object):
         self._group = last
 
     def uses(self, layer):
-        log.debug("Adding %s as mixin to %s", layer, self._group)
-        self._group.mixins.append(layer)
+        if isinstance(layer, Scenario):
+            log.debug("Embedding %s as child group of %s", layer, self._group)
+            layer._group.parent = self._group
+            self._group._children.append(layer._group)
+        else:
+            log.debug("Adding %s as mixin to %s", layer, self._group)
+            self._group.mixins.append(layer)
 
     def has_setup(self, func):
         """Add a :func:`setup` method to this group.
@@ -201,6 +247,12 @@ class Scenario(object):
     def __getattr__(self, attr):
         return getattr(self._helper, attr)
 
+    def __setattr__(self, attr, value):
+        if attr in self.__dict__.keys() or attr == "_group":
+            super(Scenario, self).__setattr__(attr, value)
+        else:
+            setattr(self._helper, attr, value)
+
     def createTests(self, mod):
         """Generate test cases for this scenario.
 
@@ -256,7 +308,7 @@ class Scenario(object):
             def _test(s, *args):
                 case(s, *args)
             return _test
-            
+
         for index, case in enumerate(group._cases):
             name = 'test %04d: %s' % (index, case.description)
             _test = _make_test_func(case)
@@ -347,9 +399,8 @@ class Group(object):
 
     """A group of tests, with common fixtures and description"""
 
-    def __init__(self, description, indent=0, parent=None, base_layer=None):
+    def __init__(self, description, parent=None, base_layer=None):
         self.description = description
-        self.indent = indent
         self.parent = parent
         self.base_layer = base_layer
         self.mixins = []
@@ -363,7 +414,6 @@ class Group(object):
     def addCase(self, case):
         if not self._cases:
             case.first = True
-        case.indent = self.indent
         self._cases.append(case)
 
     def addSetup(self, func):
@@ -388,7 +438,7 @@ class Group(object):
         return ' '.join(d)
 
     def child(self, description, base_layer=None):
-        child = Group(description, self.indent + 1, self, base_layer)
+        child = Group(description, self, base_layer)
         self._children.append(child)
         return child
 


### PR DESCRIPTION
There's about a dozen ways I could have gone with this, so I figured this is as good a place as any to start the conversation to see what your vision is for nose2, and how we can make it a bit more flexible without compromising that vision.

First, I made some changes to `Scenario` so that you can determine what is inserted before and after the description of the layer, so that it doesn't have to be `"A ..."` every time and can just be left blank. 

Next I put in the `Layer` function, which works exactly like `such.A`, with the only difference that it allows you to dictate the text that comes before and after your description, with both of those being blank by default, so:

```python
with such.A("scenario") as it:
```

would spit out as:

```
A scenario
```

but:

```python
with such.Layer("Scenario") as it:
```

would spit out as:

```
Scenario
```

Then I modified the `Scenario.uses` method so that if you pass it another `Scenario` instance, it will inject the main `Group` of the `Scenario` instance you passed into the parent `Scenario`'s list of child `Group`s, as though you had define it right there.

For example, this allows you to do something like this:

```python
with such.Layer("My Common Layer") as MyCommonLayer:

    @MyCommonLayer.has_setup
    def setUp():
        pass

    @MyCommonLayer.should("have this test")
    def test():
        assert True

    @MyCommonLayer.should("also have this test")
    def test():
        assert True

    @MyCommonLayer.should("have this test, too")
    def test():
        assert True


with such.Layer("Layer A") as LayerA:

    @LayerA.has_setup
    def setUp():
        pass

    LayerA.uses(MyCommonLayer)


with such.Layer("Layer B") as LayerB:

    @LayerB.has_setup
    def setUp():
        pass

    LayerB.uses(MyCommonLayer)


with such.A("scenario") as it:

    @it.has_setup
    def setUp():
        pass

    it.uses(LayerA)
    it.uses(LayerB)
```

to get an output like this:

```
A scenario
  Layer A
    My Common Layer
      should have this test ... ok
      should also have this test ... ok
      should have this test, too ... ok
  Layer B
    My Common Layer
      should have this test ... ok
      should also have this test ... ok
      should have this test, too ... ok
```

Also, In order to facilitate identical usage no matter where you created a layer relative to where it was used, I had to also add in a `__setattr__` method to the `Scenario` class to more heavily utilize the `_helper` attribute. As a result, if I set an attribute to the `Scenario` instance, it will almost always be applied as an attribute to the `helper` object so all `Scenario` instances will be able to access it no matter where they get made (even if they're made in another module and then imported). A similar approach is taken for deleting attributes.

These changes make it so that test suites already utilizing the `it.using` method won't be affected.

Fixes #324  