### PR TITLE
Change `getargspec` to `getfullargspec`

### DIFF
--- a/nose2/plugins/loader/functions.py
+++ b/nose2/plugins/loader/functions.py
@@ -54,7 +54,6 @@ to set ``paramList`` is with the :func:`nose2.tools.params` decorator.
 
 
 import sys
-import inspect
 import types
 
 from nose2 import util
@@ -89,8 +88,8 @@ class Functions(Plugin):
         parent, obj, name, index = result
         if (isinstance(obj, types.FunctionType) and not
             util.isgenerator(obj) and not
-            hasattr(obj, 'paramList') and not
-            inspect.getargspec(obj).args):
+            hasattr(obj, 'paramList') and
+            util.num_expected_args(obj) == 0):
             suite = event.loader.suiteClass()
             suite.addTests(self._createTests(obj))
             event.handled = True
@@ -103,7 +102,7 @@ class Functions(Plugin):
         def is_test(obj):
             if not obj.__name__.startswith(self.session.testMethodPrefix):
                 return False
-            if inspect.getargspec(obj).args:
+            if util.num_expected_args(obj) > 0:
                 return False
             return True
 

--- a/nose2/suite.py
+++ b/nose2/suite.py
@@ -1,5 +1,4 @@
 import sys
-import inspect
 import logging
 
 from nose2 import util
@@ -147,8 +146,7 @@ class LayerSuite(unittest.BaseTestSuite):
     def _inLayer(self, layer, test, method):
         meth = self._getBoundClassmethod(layer, method)
         if meth:
-            args, _, _, _ = inspect.getargspec(meth)
-            if len(args) > 1:
+            if util.num_expected_args(meth) > 1:
                 meth(test)
             else:
                 meth()

--- a/nose2/tools/such.py
+++ b/nose2/tools/such.py
@@ -1,5 +1,4 @@
 from contextlib import contextmanager
-import inspect
 import logging
 import sys
 
@@ -8,6 +7,7 @@ import six
 from nose2.compat import unittest
 from nose2 import util
 from nose2.main import PluggableTestProgram
+
 
 log = logging.getLogger(__name__)
 
@@ -273,21 +273,13 @@ class Scenario(object):
         if setups:
             def setUp(self):
                 for func in setups:
-                    args, _, _, _ = inspect.getargspec(func)
-                    if args:
-                        func(self)
-                    else:
-                        func()
+                    util.call_with_args_if_expected(func, self)
             attr['setUp'] = setUp
         teardowns = getattr(parent_layer, 'testTeardowns', []) + group._test_teardowns[:]
         if teardowns:
             def tearDown(self):
                 for func in teardowns:
-                    args, _, _, _ = inspect.getargspec(func)
-                    if args:
-                        func(self)
-                    else:
-                        func()
+                    util.call_with_args_if_expected(func, self)
             attr['tearDown'] = tearDown
 
         def methodDescription(self):
@@ -302,19 +294,11 @@ class Scenario(object):
 
         def setUp(cls):
             for func in cls.setups:
-                args, _, _, _ = inspect.getargspec(func)
-                if args:
-                    func(self)
-                else:
-                    func()
+                util.call_with_args_if_expected(func, self)
 
         def tearDown(cls):
             for func in cls.teardowns:
-                args, _, _, _ = inspect.getargspec(func)
-                if args:
-                    func(self)
-                else:
-                    func()
+                util.call_with_args_if_expected(func, self)
 
         attr = {
             'description': group.description,
@@ -410,11 +394,7 @@ class Case(object):
     def __call__(self, testcase, *args):
         # ... only if it takes an arg
         self._helper = testcase
-        funcargs, _, _, _ = inspect.getargspec(self.func)
-        if funcargs:
-            self.func(testcase, *args)
-        else:
-            self.func()
+        util.call_with_args_if_expected(self.func, testcase, *args)
 
     def __getattr__(self, attr):
         return getattr(self._helper, attr)

--- a/nose2/util.py
+++ b/nose2/util.py
@@ -12,6 +12,7 @@ import sys
 import traceback
 import platform
 import six
+import inspect
 from inspect import isgeneratorfunction  # new in 2.6
 
 
@@ -373,3 +374,21 @@ def ancestry(layer):
 
 def bases_and_mixins(layer):
     return (layer.__bases__ + getattr(layer, 'mixins', ()))
+
+
+def num_expected_args(func):
+    """Return the number of arguments that :func: expects"""
+    if six.PY2:
+        return len(inspect.getargspec(func)[0])
+    else:
+        return len(inspect.getfullargspec(func)[0])
+
+
+def call_with_args_if_expected(func, *args):
+    """Take :func: and call it with supplied :args:, in case that signature expects any.
+    Otherwise call the function without any arguments.
+    """
+    if num_expected_args(func) > 0:
+        func(*args)
+    else:
+        func()


### PR DESCRIPTION
`inspect.getargspec` is [deprecated since Python 3.0](https://docs.python.org/3/library/inspect.html#inspect.getargspec), and it breaks the test runner if using  decorators on test functions. 

`inspect.getfullargspec` is the recommended alternative:
> Use getfullargspec() for an updated API that is usually a drop-in replacement, but also correctly handles function annotations and keyword-only parameters.

In our case nose2 test runner was failing to run together with the [hypothesis](https://github.com/HypothesisWorks/hypothesis-python) property-based testing library.

This change fixes that, and possibly other similar problems that may occur.

Note that this change only affects Python 3+ code.