### PR TITLE
Improve install docs for coverage-plugin

### DIFF
--- a/nose2/plugins/coverage.py
+++ b/nose2/plugins/coverage.py
@@ -1,11 +1,11 @@
 """
 Use this plugin to activate coverage report.
 
-To use this plugin, you need to install ``coverage``:
+To use this plugin, you need to install ``nose2[coverage-plugin]``. e.g.
 
 ::
 
-    $ pip install coverage
+    $ pip install nose2[coverage-plugin]>=0.6.5
 
 
 Then, you can enable coverage reporting with :
@@ -74,8 +74,9 @@ class Coverage(Plugin):
         try:
             import coverage
         except ImportError:
-            print('Warning: you need to install [coverage-plugin] '
-                  'extra requirements to use this plugin')
+            print('Warning: you need to install "coverage-plugin" '
+                  'extra requirements to use this plugin. '
+                  'e.g. `pip install nose2[coverage-plugin]`')
             return
 
         self.covController = coverage.Coverage(source=self.covSource,


### PR DESCRIPTION
The coverage plugin docstrings should document the use of the `nose2[coverage-plugin]` extra, not direct installation of `coverage`. This way, the docs work for all versions.
Additionally, improve the ImportError warning message to properly explain installation of `nose2[coverage-plugin]`.

Because this is a common point of confusion with extras, the example in the module docstring notes how to specify the version of `nose2` at the same time as the extra.

Resolves #355