### PR TITLE
Call `Coverage.save()` during coverage reporting

### DIFF
--- a/nose2/plugins/coverage.py
+++ b/nose2/plugins/coverage.py
@@ -100,6 +100,16 @@ class Coverage(Plugin):
         """Only called if active so stop coverage and produce reports."""
         if self.covController:
             self.covController.stop()
+
+            # write to .coverage file
+            # do this explicitly (instead of passing auto_data=True to
+            # Coverage constructor) in order to not load an existing .coverage
+            # this better imitates the behavior of invoking `coverage` from the
+            # command-line, which sets `Coverage._auto_save` (triggers atexit
+            # saving to this file), but not `Coverage._auto_load`
+            # requesting a better fix in nedbat/coveragepy#34
+            self.covController.save()
+
             if 'term' in self.covReport or 'term-missing' in self.covReport:
                 # only pass `show_missing` if "term-missing" was given
                 # otherwise, just allow coverage to load show_missing from

--- a/nose2/tests/functional/test_coverage.py
+++ b/nose2/tests/functional/test_coverage.py
@@ -1,7 +1,8 @@
+import os
 import os.path
 import unittest
 
-from nose2.tests._common import FunctionalTestCase
+from nose2.tests._common import FunctionalTestCase, support_file
 
 
 class TestCoverage(FunctionalTestCase):
@@ -31,6 +32,13 @@ class TestCoverage(FunctionalTestCase):
             stderr='TOTAL\s+' + total_stats)
 
     def test_run(self):
+        # ensure there is no .coverage file at the start of test
+        reportfile = support_file('scenario/test_with_module/.coverage')
+        try:
+            os.remove(reportfile)
+        except OSError:
+            pass
+
         proc = self.runIn(
             'scenario/test_with_module',
             '-v',
@@ -38,6 +46,7 @@ class TestCoverage(FunctionalTestCase):
             '--coverage=lib/'
         )
         self.assertProcOutputPattern(proc, 'lib', '\s+8\s+5\s+38%')
+        self.assertTrue(os.path.exists(reportfile))
 
     def test_run_coverage_configs(self):
         STATS = '\s+8\s+5\s+38%\s+1, 7-10'


### PR DESCRIPTION
This writes the `.coverage` file to which people and tools are accustomed.

Also, tweak basic coverage test to catch this: ensure that a run with coverage reporting produces a .coverage file.

Resolves #362