### PR TITLE
Update setuptools invocation to handle coverage

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Running `nose2` via `setuptools` will now trigger `CreateTestsEvent` and `CreatedTestSuiteEvent`
+
 0.7.3
 -----
 * Fixed

--- a/nose2/collector.py
+++ b/nose2/collector.py
@@ -1,12 +1,19 @@
+import os
 import sys
 import unittest
 
-from nose2 import loader, runner, session
+from nose2 import loader, runner, session, events
 from nose2.main import PluggableTestProgram
 __unittest = True
 
 
 def collector():
+    """
+    This is the entry point used by setuptools, as in::
+
+      python setup.py test
+
+    """
     class Test(unittest.TestCase):
 
         def run(self, result_):
@@ -23,12 +30,49 @@ def collector():
             ssn, ldr, rnr = self._get_objects()
 
             ssn.testLoader = ldr
-            ssn.loadConfigFiles('unittest.cfg', 'nose2.cfg', 'setup.cfg')
+            ssn.loadConfigFiles('unittest.cfg', 'nose2.cfg', 'setup.cfg',
+                                os.path.expanduser('~/.unittest.cfg'),
+                                os.path.expanduser('~/.nose2.cfg'))
             ssn.setStartDir()
             ssn.prepareSysPath()
             ssn.loadPlugins(PluggableTestProgram.defaultPlugins)
 
-            test = ldr.loadTestsFromNames([], None)
+            # TODO: refactor argument parsing to make it possible to feed CLI
+            # args to plugins via this path (currently done in
+            # PluggableTestProgram)
+            # in order to do this, it seems like features in
+            # PluggableTestProgram need to be factored out into some source
+            # from which both it and this dummy test case can invoke them
+            #
+            # this is the disabled feature:
+            # ssn.hooks.handleArgs(events.CommandLineArgsEvent(...))
+            #
+            # this means that there may be plugins which don't work under
+            # setuptools invocation because they expect to get handleArgs
+            # triggered (e.g. older versions of the coverage plugin)
+
+            # FIXME: this is all a great-big DRY violation when compared with
+            # PluggableTestProgram
+
+            # create the testsuite, and make sure the createTests event gets
+            # triggered, as some plugins expect it
+            # just doing `ldr.loadTestsFromNames` works, but leaves some
+            # plugins in the lurch
+            event = events.CreateTestsEvent(ldr, [], None)
+            result = ssn.hooks.createTests(event)
+            if event.handled:
+                test = event
+            else:
+                test = ldr.loadTestsFromNames([], None)
+
+            # fire the "createdTestSuite" event for plugins to handle
+            # as above, we can get away without this, but some plugins will
+            # expect it
+            event = events.CreatedTestSuiteEvent(test)
+            result = ssn.hooks.createdTestSuite(event)
+            if event.handled:
+                test = result
+
             rslt = rnr.run(test)
             return rslt.wasSuccessful()
 

--- a/nose2/plugins/coverage.py
+++ b/nose2/plugins/coverage.py
@@ -36,9 +36,13 @@ class Coverage(Plugin):
 
     def __init__(self):
         """Get our config and add our command line arguments."""
-        self.conSource = self.config.as_list('coverage', [])
-        self.conReport = self.config.as_list('coverage-report', [])
-        self.conConfig = self.config.as_str('coverage-config', '').strip()
+
+        self.covSource = (self.config.as_list('coverage', []) or
+                          ['.'])
+        self.covReport = (self.config.as_list('coverage-report', []) or
+                          ['term'])
+        self.covConfig = (self.config.as_str('coverage-config', '').strip() or
+                          '.coveragerc')
 
         group = self.session.pluginargs
         group.add_argument(
@@ -62,13 +66,9 @@ class Coverage(Plugin):
 
     def handleArgs(self, event):
         """Get our options in order command line, config file, hard coded."""
-
-        self.covSource = (event.args.coverage_source or
-                          self.conSource or ['.'])
-        self.covReport = (event.args.coverage_report or
-                          self.conReport or ['term'])
-        self.covConfig = (event.args.coverage_config or
-                          self.conConfig or '.coveragerc')
+        self.covSource = event.args.coverage_source or self.covSource
+        self.covReport = event.args.coverage_report or self.covReport
+        self.covConfig = event.args.coverage_config or self.covConfig
 
     def createTests(self, event):
         """Start coverage early to catch imported modules.


### PR DESCRIPTION
Setuptools invocation runs differently from command-line usage. This is, itself, a potential source of grief.
Try to make it behave more like `nose2` invocation by doing the following:
- add ~/.{unittest,nose2}.cfg to loaded config
- trigger some events nose2 plugins want to use
- fix nose2.plugins.coverage to handle those events without handleArgs

Unfortunately, it looks like unifying these two modes of use more would be a significant effort, and it's not obvious that the payoff is worth the reward.

It is really easily possible that this change could break a 3rd party plugin under setuptools, since it skips the handleArgs event, but triggers some new events. However, 3rd party plugins could already be broken under setuptools by getting loaded and then not seeing these events...

Other than `nose2.plugins.coverage`, the only plugin I see using `handleArgs` is `nose2.plugins.attrib`. But attributes can't be selected if we're not processing CLI args anyway, so this is a non-issue.

Resolves #317