### PR TITLE
fix indentation of test with docstring in layers

### DIFF
--- a/nose2/plugins/layers.py
+++ b/nose2/plugins/layers.py
@@ -235,6 +235,9 @@ class LayerReporter(events.Plugin):
         if event.errorList and hasattr(event.test, 'layer'):
             # walk back layers to build full description
             self.describeLayers(event)
+        # we need to remove "\n" from description to keep a well indented report when tests have docstrings
+        # see https://github.com/nose-devs/nose2/issues/327 for more information
+        event.description = event.description.replace('\n', ' ')
 
     def describeLayers(self, event):
         desc = [event.description]

--- a/nose2/tests/functional/support/scenario/layers/test_layers.py
+++ b/nose2/tests/functional/support/scenario/layers/test_layers.py
@@ -180,6 +180,8 @@ class InnerD(unittest.TestCase):
     layer = LayerD
 
     def test(self):
+        """test with docstring
+        """
         self.assertEqual(
             {'base': 'setup',
              'layerD': 'setup'},

--- a/nose2/tests/functional/test_layers_plugin.py
+++ b/nose2/tests/functional/test_layers_plugin.py
@@ -56,7 +56,7 @@ class TestLayers(FunctionalTestCase):
 Base
   test \(test_layers.Outer\) ... ok
   LayerD
-    test \(test_layers.InnerD\) ... ok
+    test \(test_layers.InnerD\) test with docstring ... ok
   LayerA
     test \(test_layers.InnerA\) ... ok
   LayerB


### PR DESCRIPTION
Fix #327.

The output is now : 

```
LayerH
  test_1 (test_layer.T1) ... ok
  test_1 (test_layer.anotherlayer) ... ok
  Layer1
    test_with_doc (test_layer.TestClass) doc ... ok
    test_without_doc (test_layer.TestClass) ... ok

```