### PR TITLE
Add travis gitter integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,8 @@ deploy:
     repo: nose-devs/nose2
 matrix:
   fast_finish: true
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/11076bd53e2156a9a00b
+    on_start: never


### PR DESCRIPTION
Starting off with `always` notify on success and failure (default).
We'll see if that's too verbose.

From gitter
>Instructions
>
>You need to configure your Travis job to send Webhook notifications.
>
>Add the following to your .travis.yml configuration:
```
notifications:
  webhooks:
    urls:
      - YOUR_WEBHOOK_URL
    on_success: change  # options: [always|never|change] default: always
    on_failure: always  # options: [always|never|change] default: always
    on_start: never     # options: [always|never|change] default: always
```

>Your unique webhook url for this service:
```
https://webhooks.gitter.im/e/7db2aa744340ef15ab01
```