### PR TITLE
Fix tests running from an sdist download

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,7 @@ include tox.ini
 include unittest.cfg
 include README.rst
 include license.txt
-recursive-include nose2/tests/functional/support *.py *.txt *.cfg *.rst *.json *.egg
+recursive-include nose2/tests/functional/support *.py *.txt *.cfg *.rst *.json *.egg .coveragerc
 recursive-include docs *.inc *.py *.rst Makefile
 graft bin
 global-exclude __pycache__

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include AUTHORS
 include requirements.txt
-include requirements-docs.txt
+include requirements-*.txt
 include tox.ini
 include unittest.cfg
 include README.rst


### PR DESCRIPTION
When running tests from a source dist, missing test coverage configs results in testing failure. Add coveragrc the package data to make tests pass (desired for platform packaging builds).
Also adds the `requirements-*.txt` files to sdists for a similar reason.

To test, `python setup.py sdist`, then unpack the built tarball from `dist/` and run tox on it. Passes with this change, but not without.

Contributes towards #375

Aside: I think the `requirements-*` files are a little overwrought. A small dict in `setup.py` would do the same job more simply.

There is no new testing to ensure that this continues working, but I'd rather open a new issue to track that than try to get it done today. @katrinabrock, are you okay with that?