### PR TITLE
Respect fail_under coverage config

### DIFF
--- a/docs/plugins/coverage.rst
+++ b/docs/plugins/coverage.rst
@@ -3,3 +3,18 @@ Test coverage reporting
 =======================
 
 .. autoplugin :: nose2.plugins.coverage.Coverage
+
+Differences From coverage
+-------------------------
+
+The ``coverage`` tool is the basis for nose2's coverage reporting. nose2 will
+seek to emulate ``coverage`` behavior whenever possible, but there are known
+cases where this is not feasible.
+
+If you need the exact behaviors of ``coverage``, consider having ``coverage``
+invoke ``nose2``.
+
+Otherwise, please be aware of the following known differences:
+
+- The ``fail_under`` parameter results in an exit status of 2 for ``coverage``,
+  but an exit status of 1 for ``nose2``

--- a/nose2/tests/functional/support/scenario/coverage_config_fail_under/.coveragerc
+++ b/nose2/tests/functional/support/scenario/coverage_config_fail_under/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+show_missing = True
+fail_under = 80

--- a/nose2/tests/functional/support/scenario/coverage_config_fail_under/covered_lib/mod1.py
+++ b/nose2/tests/functional/support/scenario/coverage_config_fail_under/covered_lib/mod1.py
@@ -1,0 +1,10 @@
+def covered_func():
+    a = 1
+    a = a + 8
+    return a
+
+
+def uncovered_func():
+    b = 1
+    b = b + 8
+    return b

--- a/nose2/tests/functional/support/scenario/coverage_config_fail_under/test_mod.py
+++ b/nose2/tests/functional/support/scenario/coverage_config_fail_under/test_mod.py
@@ -1,0 +1,8 @@
+import unittest
+
+from covered_lib import mod1
+
+
+class TestLib(unittest.TestCase):
+    def test1(self):
+        self.assertEqual(mod1.covered_func(), 9)

--- a/nose2/tests/functional/test_coverage.py
+++ b/nose2/tests/functional/test_coverage.py
@@ -7,7 +7,7 @@ from nose2.tests._common import FunctionalTestCase, support_file
 
 class TestCoverage(FunctionalTestCase):
     def assertProcOutputPattern(self, proc, libname, stats,
-                                total_stats=None):
+                                total_stats=None, assert_exit_status=0):
         """
         - proc: a popen proc to check output on
         - libname: the name of the covered library, to build the output pattern
@@ -23,6 +23,9 @@ class TestCoverage(FunctionalTestCase):
         expected = expected + stats
 
         stdout, stderr = proc.communicate()
+
+        if assert_exit_status is not None:
+            self.assertEqual(assert_exit_status, proc.poll())
 
         self.assertTestRunOutputMatches(
             proc,
@@ -81,3 +84,17 @@ class TestCoverage(FunctionalTestCase):
         )
         self.assertProcOutputPattern(proc, 'lib20171102',
                                      stats='\s+3\s+0\s+100%')
+
+    def test_run_coverage_fail_under(self):
+        STATS = '\s+8\s+5\s+38%\s+1, 7-10'
+        TOTAL_STATS = '\s+8\s+5\s+38%\s'
+
+        proc = self.runIn(
+            'scenario/coverage_config_fail_under',
+            '-v',
+            '--with-coverage',
+            '--coverage=covered_lib/'
+        )
+        self.assertProcOutputPattern(proc, 'covered_lib', STATS,
+                                     total_stats=TOTAL_STATS,
+                                     assert_exit_status=1)


### PR DESCRIPTION
Resolves #285

- Nose2 ResultSuccessEvent events can only indicate exit(0) or exit(1),
  so without a brand new exit status handling mechanism, we can't get
  exit(2) which `coverage` does for fail_under. *This is fine*.
  Unless we expect nose2 to bend over backwards to reproduce all of the
  behaviors of coverage, this just needs to be documented.
- Previously, coverage was computed during afterSummaryReport. However,
  it must be computed before wasSuccessful in order to produce the
  correct resulting status with fail_under. Therefore, coverage is now
  computed during beforeSummaryReport, its output is buffered in a
  StringIO, and the result (for text output) is printed during
  afterSummaryReport. This should have no externally visible behavioral
  change.
- Add support to coverage tests for checking exit status, so that we can
  assert exit(1) on the fail_under test. Add a relevant test using this
  capability.
- Add documentation to coverage plugin detailing exit(2) vs exit(1)
  behavior, and leaving room for more `coverage` vs `nose2`
  discrepancies.