### PR TITLE
Fix zipped egg discovery on newer setuptools versions

### DIFF
--- a/nose2/plugins/loader/eggdiscovery.py
+++ b/nose2/plugins/loader/eggdiscovery.py
@@ -57,6 +57,11 @@ class EggDiscoveryLoader(events.Plugin, discovery.Discoverer):
         if dir_handler.event_handled:
             return
         for path in dist.resource_listdir(rel_path):
+            # on setuptools==38.2.5 , resource_listdir() can yield ""
+            # if that happens, skip processing it to avoid infinite recursion
+            if path == '':
+                continue
+
             entry_path = os.path.join(rel_path, path)
             if dist.resource_isdir(entry_path):
                 for test in self._find_tests_in_egg_dir(event, entry_path, dist):


### PR DESCRIPTION
Avoid infinite recursion when loading tests from a zipped egg. Newer setuptools can yield an empty-string when listing a dir in a zipped egg.
This looks like a setuptools bug, unless there's some subtlety to "" being returned which makes it somehow valid. Even if it is a bug, it impacts nose2 on newer setuptools versions.

I'm also going to open a setuptools issue referencing this, which should at least instruct us as to whether or not there's some particular reason for `""` to come back as a listing result.

Closes #383

This will unblock other outstanding PRs, which fail as a side-effect of this bug.