### PR TITLE
junitxml: Use test module in place of classname if no classname exists

### DIFF
--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -130,6 +130,8 @@ class JUnitXmlReporter(events.Plugin):
 
         testcase = ET.SubElement(self.tree, 'testcase')
         testcase.set('time', "%.6f" % self._time())
+        if not classname:
+            classname = test.__module__
         testcase.set('classname', classname)
         testcase.set('name', method)
 

--- a/nose2/tests/unit/test_junitxml.py
+++ b/nose2/tests/unit/test_junitxml.py
@@ -2,7 +2,7 @@ from xml.etree import ElementTree as ET
 from nose2.tests._common import TestCase
 from nose2 import events, loader, result, session, tools
 from nose2.plugins import junitxml, logcapture
-from nose2.plugins.loader import generators, parameters, testcases
+from nose2.plugins.loader import generators, parameters, testcases, functions
 
 import logging
 import os
@@ -199,6 +199,20 @@ class TestJunitXmlPlugin(TestCase):
         self.assertEqual(len(xml), 2)
         self.assertEqual(xml[0].get('name'), 'test_gen:1 (1, 1)')
         self.assertEqual(xml[1].get('name'), 'test_gen:2 (1, 2)')
+
+    def test_function_classname_is_module(self):
+        fun = functions.Functions(session=self.session)
+        fun.register()
+
+        def test_func():
+            pass
+
+        cases = fun._createTests(test_func)
+        self.assertEqual(len(cases), 1)
+        cases[0](self.result)
+        xml = self.plugin.tree.findall('testcase')
+        self.assertEqual(len(xml), 1)
+        self.assertTrue(xml[0].get('classname').endswith('test_junitxml'))
 
     def test_params_test_name_correct(self):
         # param test loading is a bit more complex than generator


### PR DESCRIPTION
I noticed an issue that the xml output for ordinary function testcases has absolutely no indication for what file the test was written in, while the generator testcases have a classname marked as the name of the module. imo the latter is desirable behavior, so I've tried to replicate it for ordinary testcases.

For one of my testcases named `test_crosspage_read` in a file named `test_memory.py`, this PR changes the XML output from this:

```
 <testcase classname="" name="test_crosspage_read" time="0.026392">
   <system-out/>
 </testcase>
```

to this:

```
  <testcase classname="test_memory" name="test_crosspage_read" time="0.042382">
    <system-out />
  </testcase>
```