### PR TITLE
get setup/teardown method after hooks are executed

### DIFF
--- a/nose2/suite.py
+++ b/nose2/suite.py
@@ -57,10 +57,10 @@ class LayerSuite(unittest.BaseTestSuite):
         if self.layer is None:
             return
 
-        setup = self._getBoundClassmethod(self.layer, 'setUp')
-
         event = events.StartLayerSetupEvent(self.layer)
         self.session.hooks.startLayerSetup(event)
+
+        setup = self._getBoundClassmethod(self.layer, 'setUp')
 
         if setup:
             setup()
@@ -113,9 +113,9 @@ class LayerSuite(unittest.BaseTestSuite):
         if self.layer is None:
             return
 
-        teardown = self._getBoundClassmethod(self.layer, 'tearDown')
         event = events.StartLayerTeardownEvent(self.layer)
         self.session.hooks.startLayerTeardown(event)
+        teardown = self._getBoundClassmethod(self.layer, 'tearDown')
         if teardown:
             teardown()
         event = events.StopLayerTeardownEvent(self.layer)


### PR DESCRIPTION
This change shouldn't impact any functionality what we have today is nose2

There is no way to skip layer setup/teardown in nose2. 
We want to have functionality to skip teardown after test completion. I am achieving that by using *startLayerTeardown* hook and replace `event.layer.tearDown` to a fake function and restore the original function during  *stopLayerTeardown* hook
Additionally this code refactoring is need 