### PR TITLE
Make ResultReporter respect the failure status set by other plugins; add test for coveragerc from config

### DIFF
--- a/nose2/events.py
+++ b/nose2/events.py
@@ -1063,6 +1063,9 @@ class ResultSuccessEvent(Event):
        Set this to ``True`` to indicate that the test run was
        successful. If no plugin sets the ``success`` to
        ``True``, the test run fails.
+       Should be initialized to ``None`` to indicate that the status has not
+       been set yet (so that plugins can always differentiate an explicit
+       failure in an earlier hook from no pass/fail status having been set yet.
 
     """
     _attrs = Event._attrs + ('result', 'success')

--- a/nose2/plugins/coverage.py
+++ b/nose2/plugins/coverage.py
@@ -146,7 +146,7 @@ class Coverage(Plugin):
 
     def wasSuccessful(self, event):
         """Mark full test run as successful or unsuccessful"""
-        if event.success and self.decided_failure:
+        if self.decided_failure:
             event.success = False
 
     def afterSummaryReport(self, event):

--- a/nose2/plugins/result.py
+++ b/nose2/plugins/result.py
@@ -107,7 +107,11 @@ class ResultReporter(events.Plugin):
         self._reportSummary(event)
 
     def wasSuccessful(self, event):
-        event.success = True
+        # if another plugin did not set it already, start by setting
+        # success=True
+        if event.success is None:
+            event.success = True
+
         for name, events in self.reportCategories.items():
             for e in events:
                 if (e.outcome == result.ERROR or

--- a/nose2/result.py
+++ b/nose2/result.py
@@ -118,7 +118,7 @@ class PluggableTestResult(object):
         try:
             return self._success
         except AttributeError:
-            event = events.ResultSuccessEvent(self, False)
+            event = events.ResultSuccessEvent(self, None)
             self.session.hooks.wasSuccessful(event)
             self._success = event.success
             return self._success

--- a/nose2/tests/functional/support/scenario/coverage_config_fail_under2/.coveragerc
+++ b/nose2/tests/functional/support/scenario/coverage_config_fail_under2/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+show_missing = True
+fail_under = 100

--- a/nose2/tests/functional/support/scenario/coverage_config_fail_under2/nose2.cfg
+++ b/nose2/tests/functional/support/scenario/coverage_config_fail_under2/nose2.cfg
@@ -1,0 +1,4 @@
+[coverage]
+always-on = True
+coverage = part_covered_lib
+coverage-config = .coveragerc

--- a/nose2/tests/functional/support/scenario/coverage_config_fail_under2/part_covered_lib/mod1.py
+++ b/nose2/tests/functional/support/scenario/coverage_config_fail_under2/part_covered_lib/mod1.py
@@ -1,0 +1,10 @@
+def covered_func():
+    a = 1
+    a = a + 8
+    return a
+
+
+def uncovered_func():
+    b = 1
+    b = b + 8
+    return b

--- a/nose2/tests/functional/support/scenario/coverage_config_fail_under2/test_part_covered_mod.py
+++ b/nose2/tests/functional/support/scenario/coverage_config_fail_under2/test_part_covered_mod.py
@@ -1,0 +1,8 @@
+import unittest
+
+from part_covered_lib import mod1
+
+
+class TestLib(unittest.TestCase):
+    def test1(self):
+        self.assertEqual(mod1.covered_func(), 9)

--- a/nose2/tests/functional/test_coverage.py
+++ b/nose2/tests/functional/test_coverage.py
@@ -98,3 +98,16 @@ class TestCoverage(FunctionalTestCase):
         self.assertProcOutputPattern(proc, 'covered_lib', STATS,
                                      total_stats=TOTAL_STATS,
                                      assert_exit_status=1)
+
+    def test_run_coverage_fail_under2(self):
+        """Check with coverage settings in config, not CLI"""
+        STATS = '\s+8\s+5\s+38%\s+1, 7-10'
+        TOTAL_STATS = '\s+8\s+5\s+38%\s'
+
+        proc = self.runIn(
+            'scenario/coverage_config_fail_under2',
+            '-v'
+        )
+        self.assertProcOutputPattern(proc, 'part_covered_lib', STATS,
+                                     total_stats=TOTAL_STATS,
+                                     assert_exit_status=1)


### PR DESCRIPTION
First of all, a goodly chunk of this is just a rebase of #395, and I don't want to pretend otherwise. I renamed the test, as it no longer fails. `coverage_config_fail_under2` may not be the most _inspired_ name, but I'm not sure it really matters.

I considered pushing this rebase to #395, but decided to open a fresh PR instead.


More importantly:
- Tweak ResultSuccessEvent to start at `None`
- Tweak ResultReporter to differentiate `None` vs `False` on the _incoming_ ResultSuccessEvent
- Tweak Coverage to ensure that it properly handles the new starting state for `ResultSuccessEvent`

There's still #397 as a related issue -- `nose2.plugins.coverage` should still either execute before or after `nose2.plugins.result` without it mattering how it was enabled -- but this resolves #396 without tackling that work (yet). Once this is done, a solution for #397 becomes easier to work on too.