### PR TITLE
Remove default=None vals from sample plugin conf

### DIFF
--- a/nose2/sphinxext.py
+++ b/nose2/sphinxext.py
@@ -134,16 +134,17 @@ class AutoPlugin(Directive):
         for var in sorted(config.vars.keys()):
             info = config.vars[var]
             entry = '  %s = ' % (var)
-            if info['type'] != 'list':
+            if info['type'] == 'list':
+                if info['default']:
+                    pad = ' ' * len(entry)
+                    entry = u'%s%s' % (entry, info['default'][0])
+                    rst.append(entry, AD)
+                    for val in info['default'][1:]:
+                        rst.append(u'%s%s' % (pad, val), AD)
+                else:
+                    rst.append(entry, AD)
+            elif info['default'] is not None:
                 entry = u'%s%s' % (entry, info['default'])
-                rst.append(entry, AD)
-            elif info['default']:
-                pad = ' ' * len(entry)
-                entry = u'%s%s' % (entry, info['default'][0])
-                rst.append(entry, AD)
-                for val in info['default'][1:]:
-                    rst.append(u'%s%s' % (pad, val), AD)
-            else:
                 rst.append(entry, AD)
         rst.append(u'', AD)
 


### PR DESCRIPTION
If a plugin configuration parameter has a default of `None`, setting it to `None` in the configuration sets it to the literal string, `'None'`. To avoid this issue and the potential for confusion, omit anything with `default=None` from the generated sample config.
This does not change the documentation of plugin parameters -- only the config generated.

To make the phrasing more natural, slightly rearranges the checks done in the sphinx extension.

closes #320