### PR TITLE
Support verbosity set in config, count `-q`

### DIFF
--- a/nose2/main.py
+++ b/nose2/main.py
@@ -155,9 +155,17 @@ class PluggableTestProgram(unittest.TestProgram):
             dest='exclude_plugins', default=[],
             help="Do not load this plugin module")
         self.argparse.add_argument(
-            '--verbose', '-v', action='count', default=0, help="print test case names and statuses")
-        self.argparse.add_argument('--quiet', action='store_const',
-                                   dest='verbose', const=0)
+            '--verbosity', type=int,
+            help=("Set starting verbosity level (int). "
+                  "Applies before -v and -q"))
+        self.argparse.add_argument(
+            '--verbose', '-v', action='count', default=0,
+            help=("Print test case names and statuses. "
+                  "Use multiple '-v's for higher verbosity."))
+        self.argparse.add_argument(
+            '--quiet', '-q', action='count', default=0, dest='quiet',
+            help=("Reduce verbosity. Multiple '-q's result in "
+                  "lower verbosity."))
         self.argparse.add_argument(
             '--log-level', default=logging.WARN,
             help='Set logging level for message logged to console.')
@@ -172,13 +180,13 @@ class PluggableTestProgram(unittest.TestProgram):
         self.session.logLevel = util.parse_log_level(cfg_args.log_level)
         logging.basicConfig(level=self.session.logLevel)
         log.debug('logging initialized %s', cfg_args.log_level)
-        if cfg_args.verbose:
-            self.session.verbosity += cfg_args.verbose
-        self.session.startDir = cfg_args.start_dir
         if cfg_args.top_level_directory:
             self.session.topLevelDir = cfg_args.top_level_directory
         self.session.loadConfigFiles(*self.findConfigFiles(cfg_args))
-        self.session.setStartDir()
+        # set verbosity from config + opts
+        self.session.setVerbosity(
+            cfg_args.verbosity, cfg_args.verbose, cfg_args.quiet)
+        self.session.setStartDir(args_start_dir=cfg_args.start_dir)
         self.session.prepareSysPath()
         if cfg_args.load_plugins:
             self.defaultPlugins.extend(cfg_args.plugins)

--- a/nose2/tests/functional/test_verbosity.py
+++ b/nose2/tests/functional/test_verbosity.py
@@ -1,0 +1,77 @@
+from nose2.tests._common import FunctionalTestCase
+
+_SUFFIX = (
+    "\n----------------------------------------------------------------------"
+    "\nRan 1 test "
+)
+
+Q_TEST_PATTERN = r"(?<!\.)(?<!ok)" + _SUFFIX
+MID_TEST_PATTERN = r"\." + _SUFFIX
+V_TEST_PATTERN = r"test \(__main__\.Test\) \.\.\. ok" + "\n" + _SUFFIX
+
+
+class TestVerbosity(FunctionalTestCase):
+    def test_no_modifier(self):
+        proc = self.runModuleAsMain("scenario/one_test/tests.py")
+        self.assertTestRunOutputMatches(proc, stderr=MID_TEST_PATTERN)
+
+    def test_one_v(self):
+        proc = self.runModuleAsMain("scenario/one_test/tests.py", "-v")
+        self.assertTestRunOutputMatches(proc, stderr=V_TEST_PATTERN)
+
+    def test_one_q(self):
+        proc = self.runModuleAsMain("scenario/one_test/tests.py", "-q")
+        self.assertTestRunOutputMatches(proc, stderr=Q_TEST_PATTERN)
+
+    def test_one_q_one_v(self):
+        proc = self.runModuleAsMain("scenario/one_test/tests.py", "-q", "-v")
+        self.assertTestRunOutputMatches(proc, stderr=MID_TEST_PATTERN)
+
+        proc = self.runModuleAsMain("scenario/one_test/tests.py", "-qv")
+        self.assertTestRunOutputMatches(proc, stderr=MID_TEST_PATTERN)
+
+    def test_one_q_two_vs(self):
+        proc = self.runModuleAsMain("scenario/one_test/tests.py", "-q", "-v", "-v")
+        self.assertTestRunOutputMatches(proc, stderr=V_TEST_PATTERN)
+
+        proc = self.runModuleAsMain("scenario/one_test/tests.py", "-qvv")
+        self.assertTestRunOutputMatches(proc, stderr=V_TEST_PATTERN)
+
+    def test_one_v_two_qs(self):
+        proc = self.runModuleAsMain("scenario/one_test/tests.py", "-v", "-q", "-q")
+        self.assertTestRunOutputMatches(proc, stderr=Q_TEST_PATTERN)
+
+        proc = self.runModuleAsMain("scenario/one_test/tests.py", "-vqq")
+        self.assertTestRunOutputMatches(proc, stderr=Q_TEST_PATTERN)
+
+    def test_explicit_verbosity(self):
+        proc = self.runModuleAsMain("scenario/one_test/tests.py", "--verbosity", "0")
+        self.assertTestRunOutputMatches(proc, stderr=Q_TEST_PATTERN)
+
+        proc = self.runModuleAsMain("scenario/one_test/tests.py", "--verbosity", "1")
+        self.assertTestRunOutputMatches(proc, stderr=MID_TEST_PATTERN)
+
+        proc = self.runModuleAsMain("scenario/one_test/tests.py", "--verbosity", "2")
+        self.assertTestRunOutputMatches(proc, stderr=V_TEST_PATTERN)
+
+        proc = self.runModuleAsMain("scenario/one_test/tests.py", "--verbosity", "-1")
+        self.assertTestRunOutputMatches(proc, stderr=Q_TEST_PATTERN)
+
+    def test_tweaked_explicit_verbosity(self):
+        proc = self.runModuleAsMain(
+            "scenario/one_test/tests.py", "--verbosity", "0", "-vv"
+        )
+        self.assertTestRunOutputMatches(proc, stderr=V_TEST_PATTERN)
+        proc = self.runModuleAsMain(
+            "scenario/one_test/tests.py", "-vv", "--verbosity", "0"
+        )
+        self.assertTestRunOutputMatches(proc, stderr=V_TEST_PATTERN)
+
+        proc = self.runModuleAsMain(
+            "scenario/one_test/tests.py", "--verbosity", "2", "-q"
+        )
+        self.assertTestRunOutputMatches(proc, stderr=MID_TEST_PATTERN)
+        proc = self.runModuleAsMain(
+            "scenario/one_test/tests.py", "-q", "--verbosity", "2", "-q"
+        )
+        self.assertTestRunOutputMatches(proc, stderr=Q_TEST_PATTERN)


### PR DESCRIPTION
- add `--verbosity` for explicitly setting the base verbosity level as an int
- add counting of `-q` option and subtract `-q`s from `-v`s
  - You can get the old behavior with `--verbosity 0`
- allow `verbosity = <int>` in config
- cleanup verbosity handling logic -- it all belongs to the session now
- change start_dir logic to follow model of verbosity logic

This is a work-in-progress, but I'm opening the PR right away with the initial work so that it can get earlier review.
It still needs additional tests for the new/altered behaviors, and additions to the 0.8.0 changelog.

This will close #310 and #115.