### PR TITLE
setup.py: Add Python 3.7 trove classifier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,12 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
-# include 3.7-dev, but put it in allow_failures (so we can easily view status,
-# but not block on it)
-- '3.7-dev'
+matrix:
+  fast_finish: true
+  include!
+  - python: '3.7'
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+    sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 install:
 - travis_retry pip install tox-travis
 - travis_retry pip install coveralls
@@ -30,10 +33,6 @@ deploy:
     tags: true
     distributions: sdist bdist_wheel
     repo: nose-devs/nose2
-matrix:
-  fast_finish: true
-  allow_failures:
-  - python: "3.7-dev"
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
 - '3.6'
 matrix:
   fast_finish: true
-  include!
+  include:
   - python: '3.7'
     dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Operating System :: OS Independent',


### PR DESCRIPTION
Upgrade the Travis CI version of Python 3.7 from prerelease to production Python 3.7 in alignment with travis-ci/travis-ci#9069 and then add the Python 3.7 trove classifier in setup.py.

