### PR TITLE
Update the requirements: coverage and six 

### DIFF
--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -277,7 +277,7 @@ ILLEGAL_REGEX_STR = \
     six.u(']')
 RESTRICTED_REGEX_STR = \
     six.u('[') + \
-    six.u('').join(["%s-%s" % (_unichr(l), _unichr(h))
+    six.u('').join(["%s-%s" % (six.unichr(l), six.unichr(h))
                     for (l, h) in RESTRICTED_RANGES]) + \
     six.u(']')
 

--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -248,15 +248,6 @@ class JUnitXmlReporter(events.Plugin):
 # xml utility functions
 #
 
-# six doesn't include a unichr function
-
-
-def _unichr(string):
-    if six.PY3:
-        return chr(string)
-    else:
-        return unichr(string)
-
 # etree outputs XML 1.0 so the 1.1 Restricted characters are invalid.
 # and there are no characters that can be given as entities aside
 # form & < > ' " which ever have to be escaped (etree handles these fine)
@@ -281,7 +272,7 @@ if sys.maxunicode > 0xFFFF:
 
 ILLEGAL_REGEX_STR = \
     six.u('[') + \
-    six.u('').join(["%s-%s" % (_unichr(l), _unichr(h))
+    six.u('').join(["%s-%s" % (six.unichr(l), six.unichr(h))
                     for (l, h) in ILLEGAL_RANGES]) + \
     six.u(']')
 RESTRICTED_REGEX_STR = \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-six>=1.7
-coverage>=4.4.1
+coverage>=4.5.1
+six>=1.11.0


### PR DESCRIPTION
Also, simplify by using [__six.unichr()__](https://six.readthedocs.io/#six.unichr).