### PR TITLE
Ensure only regular files are tested

### DIFF
--- a/nose2/plugins/loader/discovery.py
+++ b/nose2/plugins/loader/discovery.py
@@ -140,7 +140,7 @@ class Discoverer(object):
             for test in self._find_tests_in_dir(
                 event, full_path, top_level):
                 yield test
-        elif os.path.isfile(start):
+        elif os.path.isfile(start) and stat.S_ISREG((os.stat(start)).st_mode):
             for test in self._find_tests_in_file(
                 event, start, full_path, top_level):
                 yield test

--- a/nose2/tests/functional/test_discovery_loader.py
+++ b/nose2/tests/functional/test_discovery_loader.py
@@ -40,6 +40,12 @@ class DiscoveryFunctionalTest(FunctionalTestCase):
         self.assertEqual(len(self.watcher.called), 1)
         self.assertEqual(self.watcher.called[0].module.__name__, 'tests')
 
+    def test_discovery_non_regular_file(self):
+        self.session.startDir = support_file('scenario/non_regular_file')
+        event = events.LoadFromNamesEvent(self.loader, [], None)
+        result = self.session.hooks.loadTestsFromNames(event)
+        self.assertEqual(len(result._tests),0)
+
     def test_match_path_event_can_prevent_discovery(self):
         class NoTestsForYou(events.Plugin):
 


### PR DESCRIPTION
The project currently loads any file with a .py extension. This ensures that the files loaded are regular files and not pipes, fifos, or anything else that will cause the application to hang.