### PR TITLE
For issue #426. Fix the issue that multiprocess plugin hang for the event can not be …

### DIFF
--- a/nose2/plugins/mp.py
+++ b/nose2/plugins/mp.py
@@ -334,8 +334,13 @@ def procserver(session_export, conn):
         rlog.debug("Execute test %s (%s)", testid, test)
         executor(test, event.result)
         events = [e for e in ssn.hooks.flush()]
-        conn.send((testid, events))
-        rlog.debug("Log for %s returned", testid)
+        try:
+            conn.send((testid, events))
+            rlog.debug("Log for %s returned", testid)
+        except:
+            rlog.exception("Fail sending event %s: %s" % (testid, events))
+            # Send empty event list to unblock the conn.recv on main process.
+            conn.send((testid, []))
     conn.send(None)
     conn.close()
     ssn.hooks.stopSubprocess(event)


### PR DESCRIPTION
To fix issue #426.

When the event sent to main process can not be serialized, conn.send
will throw out exceptions. The worker process will exit abnormally. And
the main process will also hang at the conn.recv. So the entire unit
tests run got hang.

This change fixes this issue by catching the exception that conn.send
may throw out, log it for debugability and send empty event list to
unblock the conn.recv.