### PR TITLE
Enable pretty-assert on nose2's own testsuite

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ install_command=pip install . {packages}
 depts=coverage
 setenv=PYTHONPATH={toxinidir}
 commands=coverage erase
-         coverage run -m nose2.__main__ -v
+         coverage run -m nose2.__main__ -v --pretty-assert
          coverage report --include=*nose2* --omit=*nose2/tests*
          coverage html -d cover --include=*nose2* --omit=*nose2/tests*
 


### PR DESCRIPTION
Allows us to write `assert x == y` in our own tests. Should not alter the output from the `self.assert*()` unittest methods.

Will wait for Travis to pass, then merge.

(Reminder: please contact me on discuss@nose2.io if you want to become involved as a maintainer.)