### PR TITLE
always-on plugins still allow their CLI switches

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,12 @@ nose2 uses semantic versioning (currently in 0.x) and the popular
 Unreleased
 ----------
 
+Fixed
+~~~~~
+
+* Using a plugin's CLI flag when the plugin is already enabled via config no
+  longer errors -- it is a no-op instead
+
 0.9.0
 -----
 

--- a/nose2/events.py
+++ b/nose2/events.py
@@ -40,13 +40,17 @@ class PluginMeta(type):
             'always-on', default=instance.alwaysOn)
 
         instance.__init__(*args, **kwargs)
+
         if always_on:
             instance.register()
-        else:
-            if switch is not None:
-                short_opt, long_opt, help = switch
-                instance.addOption(
-                    instance._register_cb, short_opt, long_opt, help)
+
+        if switch is not None:
+            short_opt, long_opt, help = switch
+            if always_on:  # always-on plugins should hide their options
+                help = argparse.SUPPRESS
+            instance.addOption(
+                instance._register_cb, short_opt, long_opt, help)
+
         return instance
 
 
@@ -127,7 +131,8 @@ class Plugin(six.with_metaclass(PluginMeta)):
                     self.session.hooks.register(method, plugin)
 
     def _register_cb(self, *_):
-        self.register()
+        if not self.registered:
+            self.register()
 
     def addFlag(self, callback, short_opt, long_opt, help_text=None):
         """Add command-line flag that takes no arguments

--- a/nose2/tests/_common.py
+++ b/nose2/tests/_common.py
@@ -201,6 +201,7 @@ class NotReallyAProc(object):
         self.chdir = cwd
         self.kwargs = kwargs
         self.result = None
+        self._exit_code = None
 
     def __enter__(self):
         self._stdout = sys.__stdout__
@@ -226,7 +227,7 @@ class NotReallyAProc(object):
                     argv=('nose2',) + self.args, exit=False,
                     **self.kwargs)
             except SystemExit as e:
-                pass
+                self._exit_code = e.code
             return self.stdout.getvalue(), self.stderr.getvalue()
 
     @property
@@ -235,7 +236,7 @@ class NotReallyAProc(object):
 
     def poll(self):
         if self.result is None:
-            return 1
+            return self._exit_code if self._exit_code is not None else 1
 
         # subprocess.poll should return None or the Integer exitcode
         return int(not self.result.result.wasSuccessful())

--- a/nose2/tests/functional/test_prettyassert.py
+++ b/nose2/tests/functional/test_prettyassert.py
@@ -45,6 +45,33 @@ class TestPrettyAsserts(FunctionalTestCase):
         ])
         self.assertProcOutputPattern(proc, expected)
 
+    def test_conf_on_suppresses_clihelp(self):
+        proc = self.runIn(
+            'scenario/pretty_asserts/conf_on',
+            '--help',
+        )
+        stdout, stderr = proc.communicate()
+        exit_status = proc.poll()
+        assert '--pretty-assert' not in stdout
+        assert '--pretty-assert' not in stderr
+        assert exit_status == 0
+
+    def test_conf_on_plus_arg(self):
+        """ensures that #432 stays fixed"""
+        proc = self.runIn(
+            'scenario/pretty_asserts/conf_on',
+            '-v',
+            '--pretty-assert',
+        )
+        expected = "\n".join([
+            ">>> assert myglob == 2",
+            "",
+            "values:",
+            "    myglob = 1",
+            ""
+        ])
+        self.assertProcOutputPattern(proc, expected)
+
     def test_assign_after_assert(self):
         proc = self.runIn(
             'scenario/pretty_asserts/assign_after_assert',


### PR DESCRIPTION
If you set `always-on` in a plugin config, we should still allow the use of the relevant switch, but make it do nothing. However, we should also use `argparse.SUPPRESS` to indicate that no help output should be shown.

This way, config with many plugins loaded and always-on doesn't result in `nose2 --help` being overly-long and confusing.

Add two tests for this in the pretty-assert tests.

fixes #432

---

Will wait for Travis to pass, then merge.
Reminder: please contact me on discuss@nose2.io if you want to become involved as a maintainer.