### PR TITLE
Fix prettyassert truncating function defs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Unreleased
 Fixed
 ~~~~~
 
+* the prettyassert plugin mishandled multi-line function definitions
 * Using a plugin's CLI flag when the plugin is already enabled via config no
   longer errors -- it is a no-op instead
 

--- a/nose2/plugins/prettyassert.py
+++ b/nose2/plugins/prettyassert.py
@@ -140,11 +140,10 @@ def _get_inspection_info(trace):
         inspect.getinnerframes(trace)[-1])
     original_source_lines, firstlineno = inspect.getsourcelines(frame)
 
-    # truncate to the code in this frame
-    # - remove test function definition line
-    # - remove anything after current assert statement
+    # truncate to the code in this frame to remove anything after current
+    # assert statement
     last_index = (lineno - firstlineno + 1)
-    source_lines = original_source_lines[1:last_index]
+    source_lines = original_source_lines[:last_index]
 
     # in case the current line is actually an incomplete expression, as in
     #   assert x == (y

--- a/nose2/tests/functional/support/scenario/pretty_asserts/multiline_funcdef/test_multiline_funcdef.py
+++ b/nose2/tests/functional/support/scenario/pretty_asserts/multiline_funcdef/test_multiline_funcdef.py
@@ -1,0 +1,15 @@
+from nose2.tools.params import params
+
+
+# multiline function definition
+def test_demo(
+):
+    x = 1
+    y = 2
+    assert x > y, "oh noez, x <= y"
+
+
+@params(('foo',),
+        ('bar',))
+def test_multiline_deco(value):
+    assert not value

--- a/nose2/tests/functional/test_prettyassert.py
+++ b/nose2/tests/functional/test_prettyassert.py
@@ -106,6 +106,40 @@ class TestPrettyAsserts(FunctionalTestCase):
         ])
         self.assertProcOutputPattern(proc, expected)
 
+    def test_multiline_funcdef(self):
+        proc = self.runIn(
+            'scenario/pretty_asserts/multiline_funcdef',
+            '--pretty-assert',
+        )
+        expected1 = "\n".join([
+            '>>> assert x > y, \\"oh noez, x <= y\\"',
+            '',
+            'message:',
+            '    oh noez, x <= y',
+            '',
+            'values:',
+            '    x = 1',
+            '    y = 2',
+            ''
+        ])
+        expected2 = "\n".join([
+            '>>> assert not value',
+            '',
+            'values:',
+            "    value = 'foo'",
+            ''
+        ])
+        expected3 = "\n".join([
+            '>>> assert not value',
+            '',
+            'values:',
+            "    value = 'bar'",
+            ''
+        ])
+        self.assertProcOutputPattern(proc, expected1)
+        self.assertProcOutputPattern(proc, expected2)
+        self.assertProcOutputPattern(proc, expected3)
+
     def test_assert_attribute_resolution(self):
         proc = self.runIn(
             'scenario/pretty_asserts/attribute_resolution',


### PR DESCRIPTION
The prettyassert plugin was cutting off function definitions incorrectly. They don't actually make things harder for us to tokenize and process, so there's really no call for this.

Previously, the plugin was cutting off a line from the tops of frames. This worked in testing because all the test functions had short definitions with few parameters. But this is obviously not safe! Not only will a multiline decorator blow things up, but so will long parameter lists!

The solution is simple -- don't incorrectly truncate function definitions. Cutting off the other end of the stack frame -- after the current line -- is the part which is important and must remain.

fixes #433

---

Will wait for Travis to pass, then merge.
Reminder: please contact me on discuss@nose2.io if you want to become involved as a maintainer.