### PR TITLE
Show skip reason in junitxml "message" field

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,11 @@ nose2 uses semantic versioning (currently in 0.x) and the popular
 Unreleased
 ----------
 
+Changed
+~~~~~~~
+
+* skipped tests now include the user's reason in junit XML's "message" field
+
 Fixed
 ~~~~~
 

--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -161,7 +161,10 @@ class JUnitXmlReporter(events.Plugin):
             self.skipped += 1
             skipped = ET.SubElement(testcase, 'skipped')
             if msg:
-                skipped.set('message', 'test skipped')
+                skipmsg = 'test skipped'
+                if event.reason:
+                    skipmsg = 'test skipped: {}'.format(event.reason)
+                skipped.set('message', skipmsg)
                 skipped.text = msg
         elif event.outcome == result.FAIL and event.expected:
             self.skipped += 1

--- a/nose2/tests/functional/support/scenario/junitxml/skip_reason/test_junitxml_skip_reason.py
+++ b/nose2/tests/functional/support/scenario/junitxml/skip_reason/test_junitxml_skip_reason.py
@@ -1,0 +1,8 @@
+import unittest
+
+
+class Test(unittest.TestCase):
+
+    @unittest.skip('ohai')
+    def test(self):
+        pass

--- a/nose2/tests/functional/support/scenario/junitxml/skip_reason/unittest.cfg
+++ b/nose2/tests/functional/support/scenario/junitxml/skip_reason/unittest.cfg
@@ -1,0 +1,5 @@
+[unittest]
+plugins = nose2.plugins.junitxml
+
+[junit-xml]
+always-on = True

--- a/nose2/tests/unit/test_junitxml.py
+++ b/nose2/tests/unit/test_junitxml.py
@@ -175,7 +175,7 @@ class TestJunitXmlPlugin(TestCase):
         case = self.plugin.tree.find('testcase')
         skip = case.find('skipped')
         assert skip is not None
-        self.assertEqual(skip.get('message'), 'test skipped')
+        self.assertEqual(skip.get('message'), 'test skipped: skip')
         self.assertEqual(skip.text, 'skip')
 
     def test_skip_includes_skipped_no_reason(self):


### PR DESCRIPTION
junitxml output now includes the skip reason as part of the message in the "message" field.

closes #431

---

Will wait for Travis to pass, then merge.
Please contact me on discuss@nose2.io if you want to become involved as a maintainer.