### PR TITLE
Fix typo in Writing Plugins documentation

### DIFF
--- a/docs/dev/writing_plugins.rst
+++ b/docs/dev/writing_plugins.rst
@@ -113,11 +113,11 @@ Guidelines
 Events
 ------
 
+nose2's plugin API is based on the API in unittest2's
+``plugins`` branch (under-development). Its differs from nose's 
 in one major area: what it passes to hooks. Where nose passes a
 variety of arguments, nose2 *always passes an event*. The events are
 listed in the :doc:`event_reference`.
-nose2's plugin API is based on the API in unittest2's
-``plugins`` branch (under-development). Its differs from nose's 
 
 Here's the key thing about that: *event attributes are
 read-write*. Unless stated otherwise in the documentation for a hook,


### PR DESCRIPTION
Typo was introduced in https://github.com/nose-devs/nose2/commit/798f5992305358489f90b77a5d0d2c0d3836a168#diff-a844c9572c2cea0683998980b779a0ffL116