### PR TITLE
Add --junit-xml-path command line option 

### DIFF
--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -93,14 +93,15 @@ class JUnitXmlReporter(events.Plugin):
     commandLineSwitch = ('X', 'junit-xml', 'Generate junit-xml output report')
 
     def __init__(self):
-        self.path = os.path.realpath(
-            self.config.as_str('path', default='nose2-junit.xml'))
+        # Read argument from configuration file, or filled with default
+        self.path = os.path.abspath(self.config.as_str('path', default='') or 'nose2-junit.xml')
         self.keep_restricted = self.config.as_bool(
             'keep_restricted', default=False)
         self.test_properties = self.config.as_str(
             'test_properties', default=None)
         self.test_fullname = self.config.as_bool(
             'test_fullname', default=False)
+
         if self.test_properties is not None:
             self.test_properties_path = os.path.realpath(self.test_properties)
         self.errors = 0
@@ -109,6 +110,17 @@ class JUnitXmlReporter(events.Plugin):
         self.numtests = 0
         self.tree = ET.Element('testsuite')
         self._start = None
+
+        group = self.session.pluginargs
+        group.add_argument(
+            '--junit-xml-path', action='store', default='', metavar='FILE',
+            dest='path', help='Output XML filename'
+        )
+
+    def handleArgs(self, event):
+        """Read option from command line and override the value in config file
+        when necessary"""
+        self.path = os.path.abspath(event.args.path) or self.path
 
     def startTest(self, event):
         """Count test, record start time"""

--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -95,7 +95,7 @@ class JUnitXmlReporter(events.Plugin):
     def __init__(self):
         # Read argument from configuration file, or filled with default
         self.path = os.path.realpath(
-                self.config.as_str('path', default='nose2-junit.xml'))
+            self.config.as_str('path', default='nose2-junit.xml'))
         self.keep_restricted = self.config.as_bool(
             'keep_restricted', default=False)
         self.test_properties = self.config.as_str(
@@ -112,6 +112,7 @@ class JUnitXmlReporter(events.Plugin):
         self.tree = ET.Element('testsuite')
         self._start = None
 
+        # Allow user to override certain option from command line
         group = self.session.pluginargs
         group.add_argument(
             '--junit-xml-path', action='store', default='', metavar='FILE',

--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -94,7 +94,8 @@ class JUnitXmlReporter(events.Plugin):
 
     def __init__(self):
         # Read argument from configuration file, or filled with default
-        self.path = os.path.abspath(self.config.as_str('path', default='') or 'nose2-junit.xml')
+        self.path = os.path.realpath(
+                self.config.as_str('path', default='nose2-junit.xml'))
         self.keep_restricted = self.config.as_bool(
             'keep_restricted', default=False)
         self.test_properties = self.config.as_str(
@@ -120,7 +121,8 @@ class JUnitXmlReporter(events.Plugin):
     def handleArgs(self, event):
         """Read option from command line and override the value in config file
         when necessary"""
-        self.path = os.path.abspath(event.args.path) or self.path
+        if event.args.path:
+            self.path = os.path.realpath(event.args.path)
 
     def startTest(self, event):
         """Count test, record start time"""

--- a/nose2/tests/functional/support/scenario/junitxml/non_default_path/test_junitxml_non_default_path.py
+++ b/nose2/tests/functional/support/scenario/junitxml/non_default_path/test_junitxml_non_default_path.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+
+class Test(unittest.TestCase):
+
+    def test(self):
+        pass

--- a/nose2/tests/functional/support/scenario/junitxml/non_default_path/unittest.cfg
+++ b/nose2/tests/functional/support/scenario/junitxml/non_default_path/unittest.cfg
@@ -1,0 +1,2 @@
+[junit-xml]
+path = a.xml


### PR DESCRIPTION
Implemented command line override for specifying output xml location. Passing different xml file names is necessary while generating unit test report for multiple Tox environments. 

Related issues can be found here: https://github.com/nose-devs/nose2/issues/446