### PR TITLE
mp: initiate new session based directly on old session

### DIFF
--- a/nose2/tests/functional/test_mp_plugin.py
+++ b/nose2/tests/functional/test_mp_plugin.py
@@ -109,28 +109,18 @@ class TestMpPlugin(FunctionalTestCase):
         self.assertTrue(hasattr(conn, "send"))
         self.assertTrue(hasattr(conn, "recv"))
 
-
-class TestProcserver(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestProcserver, self).setUp()
-        self.session = session.Session()
-
     def test_dispatch_tests_receive_events(self):
-        ssn = {
-            'config': self.session.config,
-            'verbosity': 1,
-            'startDir': support_file('scenario/tests_in_package'),
-            'topLevelDir': support_file('scenario/tests_in_package'),
-            'logLevel': 100,
-            'pluginClasses': [discovery.DiscoveryLoader,
+        self.session.verbosity = 1
+        self.session.startDir = support_file('scenario/tests_in_package')
+        self.session.topLevelDir = support_file('scenario/tests_in_package')
+        self.session.logLevel = 100
+        self.pluginClasses = [discovery.DiscoveryLoader,
                               testcases.TestCaseLoader,
                               buffer.OutputBufferPlugin]
 
-        }
         conn = Conn(['pkg1.test.test_things.SomeTests.test_ok',
                      'pkg1.test.test_things.SomeTests.test_failed'])
-        procserver(ssn, conn)
+        procserver(self.plugin, conn)
 
         # check conn calls
         expect = [('pkg1.test.test_things.SomeTests.test_ok',

--- a/nose2/tests/unit/test_mp_plugin.py
+++ b/nose2/tests/unit/test_mp_plugin.py
@@ -59,19 +59,15 @@ class TestMPPlugin(TestCase):
         finally:
             sys.platform = platform
 
-    def test_session_import(self):
-        config = configparser.ConfigParser()
-        config.add_section(mp.MultiProcess.configSection)
-        export_session = {
-            "config": config,
-            "verbosity": None,
-            "startDir": '',
-            "topLevelDir": '',
-            "pluginClasses": [mp.MultiProcess]
-        }
+    def test_fresh_session(self):
         import logging
-        session = mp.import_session(logging.root, export_session)
+        self.session.config = configparser.ConfigParser()
+        self.session.config.add_section(mp.MultiProcess.configSection)
+        self.session.verbosity = None
+        self.session.startDir = ''
+        self.session.topLevelDir = ''
+        self.plugin._exportSession()
+        session = self.plugin._fresh_session(logging.root)
         self.assertIn('registerInSubprocess', session.hooks.methods)
         self.assertIn('startSubprocess', session.hooks.methods)
         self.assertIn('stopSubprocess', session.hooks.methods)
-        pass


### PR DESCRIPTION
This takes advantage of the fact that a subprocess is a full copy of the
parent process, thus it has access to all the original data.

Rather than serializing the session information and passing it through
the pipe/connection, simply pass the original MultiProcess object to
procserver() as an argument.

Cons:
* Somewhat blurs the interface between a subprocess and its parent.

Pros:
* Less code.
* Eliminates the caveat that classes must be pickeable.

Continuing on this path should allow for parent-->child data passing
that is not currently available.