### PR TITLE
Use collections.abc for Python 3.9 compatibility.

### DIFF
--- a/nose2/plugins/mp.py
+++ b/nose2/plugins/mp.py
@@ -3,7 +3,10 @@ import logging
 import multiprocessing
 import select
 import unittest
-import collections
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 import os
 import sys
@@ -307,7 +310,7 @@ def procserver(session_export, conn):
     # make a real session from the "session" we got
     ssn = import_session(rlog, session_export)
 
-    if isinstance(conn, collections.Sequence):
+    if isinstance(conn, Sequence):
         conn = connection.Client(conn[:2], authkey=conn[2])
 
     event = SubprocessEvent(ssn.testLoader,


### PR DESCRIPTION
* Importing ABC from collections module was deprecated and removed in Python 3.9 . Use `collections.abc` instead for Python 3.9 compatibility. Reference : https://github.com/python/cpython/pull/10596