### PR TITLE
Add a test for the MP-Coverage interaction

### DIFF
--- a/nose2/tests/functional/support/scenario/test_coverage_config/nose2cfg/nose2.cfg
+++ b/nose2/tests/functional/support/scenario/test_coverage_config/nose2cfg/nose2.cfg
@@ -1,2 +1,4 @@
 [coverage]
+always-on = True
 coverage-report = term-missing
+coverage = covered_lib_nose2cfg/

--- a/nose2/tests/functional/test_coverage.py
+++ b/nose2/tests/functional/test_coverage.py
@@ -67,11 +67,29 @@ class TestCoverage(FunctionalTestCase):
         proc = self.runIn(
             'scenario/test_coverage_config/nose2cfg',
             '-v',
-            '--with-coverage',
-            '--coverage=covered_lib_nose2cfg/'
         )
         self.assertProcOutputPattern(proc, 'covered_lib_nose2cfg', STATS,
                                      total_stats=TOTAL_STATS)
+
+
+    def test_run_with_mp(self):
+        # this test needs to be done with nose2 config because (as of 2019-12)
+        # multiprocessing does not allow each test process to pick up on
+        # command line arguments
+
+        # run with 4 processes -- this will fail if `coverage` isn't running in
+        # a "parallel" mode (with a "data suffix" set and combining results for
+        # reporting)
+        proc = self.runIn(
+            'scenario/test_coverage_config/nose2cfg',
+            '-v',
+            '--plugin=nose2.plugins.mp',
+            '-N', '4',
+        )
+        self.assertProcOutputPattern(
+            proc, 'covered_lib_nose2cfg',
+            r'\s+8\s+5\s+38%\s+1, 7-10', total_stats=r'\s+8\s+5\s+38%'
+        )
 
     # FIXME: figure out why this fails and remove @skip
     @unittest.skip('fails in testsuite but passes in real-world conditions')


### PR DESCRIPTION
Follow-up to #449 -- this test fails prior to that change.

Switch the nose2cfg coverage test to pull all info into the config file, as MP-coverage runs can't parse CLI args. Then, add a test which runs on the nose2cfg config with the MP plugin enabled.

While I have this passing locally, I'm putting it through it's paces as a PR to ensure that it works correctly in Travis CI.