### PR TITLE
test_name: Fix name conversion for UnitTest methods.

### DIFF
--- a/nose2/util.py
+++ b/nose2/util.py
@@ -183,9 +183,12 @@ def test_name(test, qualname=True):
     if hasattr(test, '_funcName'):
         tid = test._funcName
     elif hasattr(test, '_testFunc'):
-        # this is a UnitTest-wrapped function
-        if sys.version_info >= (3, 3):
-            tid = "%s.%s" % (test._testFunc.__module__, test._testFunc.__qualname__)
+        if any("__unittest" in attr for attr in dir(test._testFunc)):
+            # this is a UnitTest-wrapped function
+            if sys.version_info >= (3, 3):
+                tid = "%s.%s" % (test._testFunc.__module__, test._testFunc.__qualname__)
+            else:
+                tid = "%s.%s" % (test._testFunc.__module__, test._testFunc.__name__)
         else:
             tid = "%s.%s" % (test._testFunc.__module__, test._testFunc.__name__)
     else:

--- a/nose2/util.py
+++ b/nose2/util.py
@@ -187,7 +187,7 @@ def test_name(test, qualname=True):
         if sys.version_info >= (3, 3):
             tid = "%s.%s" % (test._testFunc.__module__, test._testFunc.__qualname__)
         else:
-            tid = "%s.%s" % (test._testFunc.__module__, test._testFunc.im_class)
+            tid = "%s.%s" % (test._testFunc.__module__, test._testFunc.__name__)
     else:
         if sys.version_info >= (3, 5) and not qualname:
             test_module = test.__class__.__module__

--- a/nose2/util.py
+++ b/nose2/util.py
@@ -183,7 +183,11 @@ def test_name(test, qualname=True):
     if hasattr(test, '_funcName'):
         tid = test._funcName
     elif hasattr(test, '_testFunc'):
-        tid = "%s.%s" % (test._testFunc.__module__, test._testFunc.__name__)
+        # this is a UnitTest-wrapped function
+        if sys.version_info >= (3, 3):
+            tid = "%s.%s" % (test._testFunc.__module__, test._testFunc.__qualname__)
+        else:
+            tid = "%s.%s" % (test._testFunc.__module__, test._testFunc.im_class)
     else:
         if sys.version_info >= (3, 5) and not qualname:
             test_module = test.__class__.__module__


### PR DESCRIPTION
For UnitTest-wrapped functions, test_name() would convert a
module.class.test_function into "module.test_function" and lose the
class information. This is, unfortunately, not expected by the
MultiProcess plugin, which has a different way of converting tests to
their testids. This fix ensures for UnitTest-wrapped functions,
test_name() returns a "module.class.function"-style name that complies
with the manner that MultiProcess plugin expects.

This PR fixes issue #465.