### PR TITLE
Ignore top-level setup.py when scanning for doctests.

### DIFF
--- a/nose2/plugins/doctests.py
+++ b/nose2/plugins/doctests.py
@@ -42,6 +42,9 @@ class DocTestLoader(Plugin):
             return
 
         name, package_path = util.name_from_path(path)
+        # ignore top-level setup.py which cannot be imported
+        if name == 'setup':
+            return
         util.ensure_importable(package_path)
         try:
             module = util.module_from_name(name)

--- a/nose2/tests/unit/test_doctest_plugin.py
+++ b/nose2/tests/unit/test_doctest_plugin.py
@@ -2,6 +2,8 @@
 import sys
 import doctest
 
+from textwrap import dedent
+
 from nose2 import events, loader, session
 from nose2.plugins import doctests
 from nose2.tests._common import TestCase
@@ -59,6 +61,22 @@ def func():
             self.assertEqual(event.extraTests, [doctest.DocTestSuite()])
         else:
             self.assertEqual(event.extraTests, [])
+
+    def test_handle_file_python_setup_py(self):
+        # Test calling handleFile on a top-level setup.py file.
+        # The file should be ignored by the plugin as it cannot safely be
+        # imported.
+
+        setup_py = dedent("""\
+            '''
+            >>> never executed
+            '''
+            from setuptools import setup
+            setup(name='foo')
+            """
+        )
+        event = self._handle_file("setup.py", setup_py)
+        self.assertEqual(event.extraTests, [])
 
     def _handle_file(self, fpath, content):
         """Have plugin handle a file with certain content.


### PR DESCRIPTION
Fixes issue where the doctest loader would try to import a package's setup.py and blow up.

This fixes #460 for the common case.