### PR TITLE
mp: Get the correct class name for test classes.

### DIFF
--- a/nose2/plugins/mp.py
+++ b/nose2/plugins/mp.py
@@ -243,6 +243,9 @@ class MultiProcess(events.Plugin):
                         mods.setdefault(test.__class__.__module__, []).append(
                             testid)
                     elif util.has_class_fixtures(test):
+                        if test.__class__.__name__ == "_MethodTestCase":
+                            # wrapped by MethodTestCase in testclasses.py
+                            test = test.obj
                         classes.setdefault(
                             "%s.%s" % (test.__class__.__module__,
                                        test.__class__.__name__),


### PR DESCRIPTION
Test classes are wrapped around by the MethodTestCase class in
plugins/loader/testclasses.py. Unwrap them before retrieving the module
and the class name of the actual test class in the mp plugin.

This PR fixes the issue that the mp plugin fails to load any test cases that are inside a UnitTest class. My current check on `test.__class__.__name__` is hacky - I am open to better ideas!