### PR TITLE
Ignore test methods even when of types.FunctionType.

### DIFF
--- a/nose2/plugins/loader/functions.py
+++ b/nose2/plugins/loader/functions.py
@@ -87,6 +87,7 @@ class Functions(Plugin):
 
         parent, obj, name, index = result
         if (isinstance(obj, types.FunctionType) and not
+            isinstance(parent, type) and not
             util.isgenerator(obj) and not
             hasattr(obj, 'paramList') and
             util.num_expected_args(obj) == 0):

--- a/nose2/tests/unit/test_functions_loader.py
+++ b/nose2/tests/unit/test_functions_loader.py
@@ -1,4 +1,11 @@
 import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    # Python versions older than 3.3 don't have mock by default
+    import mock
+
 from nose2 import events, loader, session
 from nose2.plugins.loader import functions
 from nose2.tests._common import TestCase
@@ -47,3 +54,37 @@ class TestFunctionLoader(TestCase):
         event = events.LoadFromModuleEvent(self.loader, m)
         self.session.hooks.loadTestsFromModule(event)
         self.assertEqual(len(event.extraTests), 0)
+
+    def test_can_load_test_functions_from_name(self):
+        event = events.LoadFromNameEvent(self.loader, __name__+'.func', None)
+        suite = self.session.hooks.loadTestsFromName(event)
+        self.assertNotEqual(suite, None)
+
+    def test_ignores_test_methods_from_name(self):
+        # Should ignore test methods even when specified directly
+        event = events.LoadFromNameEvent(self.loader, __name__+'.Case.test_method', None)
+        suite = self.session.hooks.loadTestsFromName(event)
+        self.assertEqual(suite, None)
+
+    def test_ignores_decorated_test_methods_from_name(self):
+        # Should ignore test methods even when they are of FunctionType
+        event = events.LoadFromNameEvent(self.loader, __name__+'.Case.test_patched', None)
+        suite = self.session.hooks.loadTestsFromName(event)
+        self.assertEqual(suite, None)
+
+
+def func():
+    pass
+
+def dummy():
+    pass
+
+class Case(unittest.TestCase):
+    __test__ = False # do not run this
+
+    def test_method(self):
+        pass
+
+    @mock.patch(__name__+'.dummy')
+    def test_patched(self, mock):
+        pass


### PR DESCRIPTION
Stop functions loader from accepting class methods even when they are decorated (with e.g. mock.patch) and thus of types.FunctionType.

This fixes #468 and half of #444.