### PR TITLE
Update test functions id, str, and repr.

### DIFF
--- a/nose2/plugins/loader/functions.py
+++ b/nose2/plugins/loader/functions.py
@@ -140,6 +140,14 @@ class Functions(Plugin):
             return tests
         else:
             case = util.transplant_class(
-                unittest.FunctionTestCase, obj.__module__)(obj, **args)
+                FunctionTestCase, obj.__module__)(obj, **args)
             tests.append(case)
         return tests
+
+
+class FunctionTestCase(unittest.FunctionTestCase):
+
+    def __repr__(self):
+        return '%s.%s' % (self._testFunc.__module__, self._testFunc.__name__)
+
+    id = __str__ = __repr__

--- a/nose2/tests/functional/test_loading.py
+++ b/nose2/tests/functional/test_loading.py
@@ -82,6 +82,15 @@ class TestLoadTestsFromPackage(FunctionalTestCase):
             proc, stderr='OK')
         self.assertEqual(proc.poll(), 0)
 
+    def test_function_string_repr(self):
+        proc = self.runIn(
+            'scenario/tests_in_package',
+            '-v',
+            'pkg1.test.test_things.test_func')
+        self.assertTestRunOutputMatches(
+            proc, stderr='pkg1.test.test_things.test_func \.\.\. ok')
+        self.assertEqual(proc.poll(), 0)
+
     def test_generator_function_name(self):
         proc = self.runIn(
             'scenario/tests_in_package',


### PR DESCRIPTION
Make id and repr for test functions work the same as for test classes, generators, and parameterized tests.
    
Fixes issue where `transplant_class.<locals>.C` was printed as part of a FunctionTestCase's string representation. Also makes test.id() work.

Fixes #475.