### PR TITLE
testclasses mp support

### DIFF
--- a/nose2/plugins/attrib.py
+++ b/nose2/plugins/attrib.py
@@ -138,7 +138,11 @@ def _get_attr(test, key):
         if val is not undefined:
             return val
     elif hasattr(test, '_testMethodName'):
-        meth = getattr(test, test._testMethodName, undefined)
+        # testclasses support
+        if test.__class__.__name__ == '_MethodTestCase':
+            meth = getattr(test.obj, test.method, undefined)
+        else:
+            meth = getattr(test, test._testMethodName, undefined)
         if meth is not undefined:
             val = getattr(meth, key, undefined)
             if val is not undefined:

--- a/nose2/plugins/loader/generators.py
+++ b/nose2/plugins/loader/generators.py
@@ -243,13 +243,15 @@ class GeneratorFunctionCase(unittest.FunctionTestCase):
 def GeneratorMethodCase(cls):
     class _GeneratorMethodCase(GeneratorFunctionCase):
 
-        @classmethod
-        def setUpClass(klass):
-            if hasattr(cls, 'setUpClass'):
-                cls.setUpClass()
+        if util.has_class_fixtures(cls):
+            @classmethod
+            def setUpClass(klass):
+                if hasattr(cls, 'setUpClass'):
+                    cls.setUpClass()
 
-        @classmethod
-        def tearDownClass(klass):
-            if hasattr(cls, 'tearDownClass'):
-                cls.tearDownClass()
+            @classmethod
+            def tearDownClass(klass):
+                if hasattr(cls, 'tearDownClass'):
+                    cls.tearDownClass()
+
     return _GeneratorMethodCase

--- a/nose2/plugins/loader/generators.py
+++ b/nose2/plugins/loader/generators.py
@@ -133,7 +133,7 @@ class Generators(Plugin):
             )
         elif (parent and
               isinstance(parent, type)):
-              # generator method in test class
+            # generator method in test class
             method = obj
             instance = parent()
             tests = list(
@@ -254,4 +254,6 @@ def GeneratorMethodCase(cls):
                 if hasattr(cls, 'tearDownClass'):
                     cls.tearDownClass()
 
+    # XXX retain original class name
+    _GeneratorMethodCase.__name__ = cls.__name__
     return _GeneratorMethodCase

--- a/nose2/plugins/loader/parameters.py
+++ b/nose2/plugins/loader/parameters.py
@@ -137,15 +137,16 @@ class Parameters(Plugin):
         if (parent and
             isinstance(parent, type) and
             issubclass(parent, unittest.TestCase)):
-            # generator method
+            # parameterized method in test case
             names = self._generate(event, obj.__name__, obj, parent)
             tests = [parent(n) for n in names]
         elif (parent and
               isinstance(parent, type)):
-            names = self._generate(event, name, obj, parent)
+            # parameterized method in test class
+            names = self._generate(event, obj.__name__, obj, parent)
             tests = [MethodTestCase(parent)(name) for name in names]
         else:
-            # generator func
+            # parameterized func
             tests = list(self._generateFuncTests(obj))
 
         if index is not None:

--- a/nose2/plugins/loader/testclasses.py
+++ b/nose2/plugins/loader/testclasses.py
@@ -219,6 +219,10 @@ def MethodTestCase(cls):
         def runTest(self):
             getattr(self.obj, self.method)()
 
+        def shortDescription(self):
+            doc = getattr(self.obj, self.method).__doc__
+            return doc and doc.split("\n")[0].strip() or None
+
     return _MethodTestCase
 
 #

--- a/nose2/plugins/loader/testclasses.py
+++ b/nose2/plugins/loader/testclasses.py
@@ -193,15 +193,16 @@ def MethodTestCase(cls):
             self.obj = cls()
             unittest.TestCase.__init__(self, 'runTest')
 
-        @classmethod
-        def setUpClass(klass):
-            if hasattr(cls, 'setUpClass'):
-                cls.setUpClass()
+        if util.has_class_fixtures(cls):
+            @classmethod
+            def setUpClass(klass):
+                if hasattr(cls, 'setUpClass'):
+                    cls.setUpClass()
 
-        @classmethod
-        def tearDownClass(klass):
-            if hasattr(cls, 'tearDownClass'):
-                cls.tearDownClass()
+            @classmethod
+            def tearDownClass(klass):
+                if hasattr(cls, 'tearDownClass'):
+                    cls.tearDownClass()
 
         def setUp(self):
             if hasattr(self.obj, 'setUp'):

--- a/nose2/plugins/mp.py
+++ b/nose2/plugins/mp.py
@@ -273,10 +273,10 @@ class MultiProcess(events.Plugin):
             try:
                 event.test = self.cases[event.test]
             except KeyError:
-                event.test = self.session.testLoader.failedLoadTests(
-                    'test_not_found',
-                    RuntimeError("Unable to locate test case for %s in "
-                                 "main process" % event.test))._tests[0]
+                # this happens when _flatten augments the test suite
+                # due to a class or module fixture being present
+                event.test = self.session.testLoader.loadTestsFromName(
+                    event.test)._tests[0]
             # subtest support
             if 'subtest' in event.metadata:
                 message, params = event.metadata.pop('subtest')

--- a/nose2/plugins/mp.py
+++ b/nose2/plugins/mp.py
@@ -243,6 +243,9 @@ class MultiProcess(events.Plugin):
                         mods.setdefault(test.__class__.__module__, []).append(
                             testid)
                     elif util.has_class_fixtures(test):
+                        # testclasses support
+                        if test.__class__.__name__ == '_MethodTestCase':
+                            test = test.obj
                         classes.setdefault(
                             "%s.%s" % (test.__class__.__module__,
                                        test.__class__.__name__),
@@ -481,7 +484,7 @@ class RecordingPluginInterface(events.PluginInterface):
     hookClass = RecordingHook
     noLogMethods = set(
         ['getTestCaseNames', 'startSubprocess', 'stopSubprocess',
-         'registerInSubprocess', 'moduleLoadedSuite'])
+         'registerInSubprocess', 'moduleLoadedSuite', 'getTestMethodNames'])
 
     def __init__(self):
         super(RecordingPluginInterface, self).__init__()

--- a/nose2/tests/functional/support/scenario/test_classes_mp/test_classes_mp.py
+++ b/nose2/tests/functional/support/scenario/test_classes_mp/test_classes_mp.py
@@ -1,0 +1,14 @@
+class Test(object):
+
+    def test(self):
+        pass
+
+    def test_gen(self):
+        def check(a):
+            pass
+        for i in range(0, 5):
+            yield check, i
+
+    def test_params(self, a):
+        pass
+    test_params.paramList = (1, 2)

--- a/nose2/tests/functional/support/scenario/test_classes_mp/test_fixtures_mp.py
+++ b/nose2/tests/functional/support/scenario/test_classes_mp/test_fixtures_mp.py
@@ -1,0 +1,31 @@
+class Test(object):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.setup = 1
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.setup
+
+    def setUp(self):
+        self.test_setup = 1
+
+    def tearDown(self):
+        del self.test_setup
+
+    def test(self):
+        assert self.test_setup
+        assert self.setup
+
+    def test_gen(self):
+        def check(a):
+            assert self.test_setup
+            assert self.setup
+        for i in range(0, 2):
+            yield check, i
+
+    def test_params(self, a):
+        assert self.test_setup
+        assert self.setup
+    test_params.paramList = (1, 2)

--- a/nose2/tests/functional/test_mp_plugin.py
+++ b/nose2/tests/functional/test_mp_plugin.py
@@ -185,6 +185,15 @@ class MPPluginTestRuns(FunctionalTestCase):
         self.assertTestRunOutputMatches(proc, stderr='Ran 3 tests')
         self.assertEqual(proc.poll(), 1)
 
+    def test_test_classes(self):
+        proc = self.runIn(
+            'scenario/test_classes_mp',
+            '-v',
+            '--plugin=nose2.plugins.mp',
+            '-N=2')
+        self.assertTestRunOutputMatches(proc, stderr='Ran 13 tests')
+        self.assertEqual(proc.poll(), 0)
+
     def test_module_fixtures(self):
         proc = self.runIn(
             'scenario/module_fixtures',

--- a/nose2/tests/functional/test_mp_plugin.py
+++ b/nose2/tests/functional/test_mp_plugin.py
@@ -185,15 +185,6 @@ class MPPluginTestRuns(FunctionalTestCase):
         self.assertTestRunOutputMatches(proc, stderr='Ran 3 tests')
         self.assertEqual(proc.poll(), 1)
 
-    def test_test_classes(self):
-        proc = self.runIn(
-            'scenario/test_classes_mp',
-            '-v',
-            '--plugin=nose2.plugins.mp',
-            '-N=2')
-        self.assertTestRunOutputMatches(proc, stderr='Ran 13 tests')
-        self.assertEqual(proc.poll(), 0)
-
     def test_module_fixtures(self):
         proc = self.runIn(
             'scenario/module_fixtures',
@@ -295,3 +286,55 @@ class MPPluginTestRuns(FunctionalTestCase):
         )
         self.assertTestRunOutputMatches(proc, stderr=expected_results)
         self.assertEqual(proc.poll(), 1)
+
+
+class MPTestClassSupport(FunctionalTestCase):
+
+    def test_testclass_discover(self):
+        proc = self.runIn(
+            'scenario/test_classes_mp',
+            '-v',
+            '--plugin=nose2.plugins.mp',
+            '-N=2')
+        self.assertTestRunOutputMatches(proc, stderr='Ran 13 tests')
+        self.assertEqual(proc.poll(), 0)
+
+    def test_testclass_by_module(self):
+        proc = self.runIn(
+            'scenario/test_classes_mp',
+            '-v',
+            '--plugin=nose2.plugins.mp',
+            '-N=2',
+            'test_classes_mp')
+        self.assertTestRunOutputMatches(proc, stderr='Ran 8 tests')
+        self.assertEqual(proc.poll(), 0)
+
+    def test_testclass_by_class(self):
+        proc = self.runIn(
+            'scenario/test_classes_mp',
+            '-v',
+            '--plugin=nose2.plugins.mp',
+            '-N=2',
+            'test_classes_mp.Test')
+        self.assertTestRunOutputMatches(proc, stderr='Ran 8 tests')
+        self.assertEqual(proc.poll(), 0)
+
+    def test_testclass_parameters(self):
+        proc = self.runIn(
+            'scenario/test_classes_mp',
+            '-v',
+            '--plugin=nose2.plugins.mp',
+            '-N=2',
+            'test_classes_mp.Test.test_params')
+        self.assertTestRunOutputMatches(proc, stderr='Ran 2 tests')
+        self.assertEqual(proc.poll(), 0)
+
+    def test_testclass_generators(self):
+        proc = self.runIn(
+            'scenario/test_classes_mp',
+            '-v',
+            '--plugin=nose2.plugins.mp',
+            '-N=2',
+            'test_classes_mp.Test.test_gen')
+        self.assertTestRunOutputMatches(proc, stderr='Ran 5 tests')
+        self.assertEqual(proc.poll(), 0)

--- a/nose2/tests/functional/test_mp_plugin.py
+++ b/nose2/tests/functional/test_mp_plugin.py
@@ -362,6 +362,19 @@ class MPClassFixturesSupport(FunctionalTestCase):
         self.assertTestRunOutputMatches(proc, stderr='Ran 2 tests')
         self.assertEqual(proc.poll(), 0)
 
+    def test_testcase_class_fixtures_report_mp(self):
+        proc = self.runIn(
+            'scenario/class_fixtures',
+            '-v',
+            '--plugin=nose2.plugins.mp',
+            '-N=2',
+            'test_cf_testcase.Test.test_1')
+        # report should show correct names for all tests
+        self.assertTestRunOutputMatches(proc, stderr='test_1 \(test_cf_testcase.Test\) ... ok')
+        self.assertTestRunOutputMatches(proc, stderr='test_2 \(test_cf_testcase.Test\) ... ok')
+        self.assertTestRunOutputMatches(proc, stderr='Ran 2 tests')
+        self.assertEqual(proc.poll(), 0)
+
     def test_testclass_class_fixtures_and_parameters(self):
         proc = self.runIn(
             'scenario/test_classes_mp',
@@ -422,5 +435,18 @@ class MPModuleFixturesSupport(FunctionalTestCase):
             '-N=2',
             'test_mf_testcase.Test.test_1')
         # XXX mp plugin runs the entire module if a module fixture is detected
+        self.assertTestRunOutputMatches(proc, stderr='Ran 2 tests')
+        self.assertEqual(proc.poll(), 0)
+
+    def test_testcase_module_fixtures_report_mp(self):
+        proc = self.runIn(
+            'scenario/module_fixtures',
+            '-v',
+            '--plugin=nose2.plugins.mp',
+            '-N=2',
+            'test_mf_testcase.Test.test_1')
+        # report should show correct names for all tests
+        self.assertTestRunOutputMatches(proc, stderr='test_1 \(test_mf_testcase.Test\) ... ok')
+        self.assertTestRunOutputMatches(proc, stderr='test_2 \(test_mf_testcase.Test\) ... ok')
         self.assertTestRunOutputMatches(proc, stderr='Ran 2 tests')
         self.assertEqual(proc.poll(), 0)

--- a/nose2/tests/functional/test_mp_plugin.py
+++ b/nose2/tests/functional/test_mp_plugin.py
@@ -338,3 +338,46 @@ class MPTestClassSupport(FunctionalTestCase):
             'test_classes_mp.Test.test_gen')
         self.assertTestRunOutputMatches(proc, stderr='Ran 5 tests')
         self.assertEqual(proc.poll(), 0)
+
+
+class MPClassFixturesSupport(FunctionalTestCase):
+
+    def test_testcase_class_fixtures(self):
+        proc = self.runIn(
+            'scenario/class_fixtures',
+            '-v',
+            'test_cf_testcase.Test.test_1')
+        # main process runs selected tests
+        self.assertTestRunOutputMatches(proc, stderr='Ran 1 test')
+        self.assertEqual(proc.poll(), 0)
+
+    def test_testcase_class_fixtures_mp(self):
+        proc = self.runIn(
+            'scenario/class_fixtures',
+            '-v',
+            '--plugin=nose2.plugins.mp',
+            '-N=2',
+            'test_cf_testcase.Test.test_1')
+        # XXX mp plugin runs the entire class if a class fixture is detected
+        self.assertTestRunOutputMatches(proc, stderr='Ran 2 tests')
+        self.assertEqual(proc.poll(), 0)
+
+    def test_testclass_class_fixtures(self):
+        proc = self.runIn(
+            'scenario/test_classes_mp',
+            '-v',
+            'test_fixtures_mp.Test.test_params')
+        # main process runs selected tests
+        self.assertTestRunOutputMatches(proc, stderr='Ran 2 tests')
+        self.assertEqual(proc.poll(), 0)
+
+    def test_testclass_class_fixtures_mp(self):
+        proc = self.runIn(
+            'scenario/test_classes_mp',
+            '-v',
+            '--plugin=nose2.plugins.mp',
+            '-N=2',
+            'test_fixtures_mp.Test.test_params')
+        # XXX mp plugin runs the entire class if a class fixture is detected
+        self.assertTestRunOutputMatches(proc, stderr='Ran 5 tests')
+        self.assertEqual(proc.poll(), 0)

--- a/nose2/tests/functional/test_mp_plugin.py
+++ b/nose2/tests/functional/test_mp_plugin.py
@@ -362,7 +362,7 @@ class MPClassFixturesSupport(FunctionalTestCase):
         self.assertTestRunOutputMatches(proc, stderr='Ran 2 tests')
         self.assertEqual(proc.poll(), 0)
 
-    def test_testclass_class_fixtures(self):
+    def test_testclass_class_fixtures_and_parameters(self):
         proc = self.runIn(
             'scenario/test_classes_mp',
             '-v',
@@ -371,13 +371,33 @@ class MPClassFixturesSupport(FunctionalTestCase):
         self.assertTestRunOutputMatches(proc, stderr='Ran 2 tests')
         self.assertEqual(proc.poll(), 0)
 
-    def test_testclass_class_fixtures_mp(self):
+    def test_testclass_class_fixtures_and_parameters_mp(self):
         proc = self.runIn(
             'scenario/test_classes_mp',
             '-v',
             '--plugin=nose2.plugins.mp',
             '-N=2',
             'test_fixtures_mp.Test.test_params')
+        # XXX mp plugin runs the entire class if a class fixture is detected
+        self.assertTestRunOutputMatches(proc, stderr='Ran 5 tests')
+        self.assertEqual(proc.poll(), 0)
+
+    def test_testclass_class_fixtures_and_generators(self):
+        proc = self.runIn(
+            'scenario/test_classes_mp',
+            '-v',
+            'test_fixtures_mp.Test.test_gen')
+        # main process runs selected tests
+        self.assertTestRunOutputMatches(proc, stderr='Ran 2 tests')
+        self.assertEqual(proc.poll(), 0)
+
+    def test_testclass_class_fixtures_and_generators_mp(self):
+        proc = self.runIn(
+            'scenario/test_classes_mp',
+            '-v',
+            '--plugin=nose2.plugins.mp',
+            '-N=2',
+            'test_fixtures_mp.Test.test_gen')
         # XXX mp plugin runs the entire class if a class fixture is detected
         self.assertTestRunOutputMatches(proc, stderr='Ran 5 tests')
         self.assertEqual(proc.poll(), 0)

--- a/nose2/tests/functional/test_mp_plugin.py
+++ b/nose2/tests/functional/test_mp_plugin.py
@@ -401,3 +401,26 @@ class MPClassFixturesSupport(FunctionalTestCase):
         # XXX mp plugin runs the entire class if a class fixture is detected
         self.assertTestRunOutputMatches(proc, stderr='Ran 5 tests')
         self.assertEqual(proc.poll(), 0)
+
+
+class MPModuleFixturesSupport(FunctionalTestCase):
+
+    def test_testcase_module_fixtures(self):
+        proc = self.runIn(
+            'scenario/module_fixtures',
+            '-v',
+            'test_mf_testcase.Test.test_1')
+        # main process runs selected tests
+        self.assertTestRunOutputMatches(proc, stderr='Ran 1 test')
+        self.assertEqual(proc.poll(), 0)
+
+    def test_testcase_module_fixtures_mp(self):
+        proc = self.runIn(
+            'scenario/module_fixtures',
+            '-v',
+            '--plugin=nose2.plugins.mp',
+            '-N=2',
+            'test_mf_testcase.Test.test_1')
+        # XXX mp plugin runs the entire module if a module fixture is detected
+        self.assertTestRunOutputMatches(proc, stderr='Ran 2 tests')
+        self.assertEqual(proc.poll(), 0)

--- a/nose2/tests/unit/test_mp_plugin.py
+++ b/nose2/tests/unit/test_mp_plugin.py
@@ -29,6 +29,8 @@ class TestMPPlugin(TestCase):
         rpi.registerInSubprocess(None)
         rpi.loadTestsFromModule(None)
         rpi.loadTestsFromTestCase(None)
+        rpi.moduleLoadedSuite(None)
+        rpi.getTestMethodNames(None)
         self.assertEqual(rpi.flush(), [('setTestOutcome', None)])
 
     def test_address(self):

--- a/nose2/tests/unit/test_util.py
+++ b/nose2/tests/unit/test_util.py
@@ -33,3 +33,46 @@ class UtilTests(TestCase):
             'nose2.tests.unit.test_util.UtilTests.test_ensure_importable (i=1, j=2)')
         self.assertEqual(util.test_name(test),
             'nose2.tests.unit.test_util.UtilTests.test_ensure_importable')
+
+
+class HasClassFixturesTests(TestCase):
+
+    def test_unittest_testcase(self):
+        C = unittest.TestCase
+        self.assertFalse(util.has_class_fixtures(C))
+        self.assertFalse(util.has_class_fixtures(C()))
+
+    def test_derived_testcase(self):
+        class C(unittest.TestCase):
+            pass
+        self.assertFalse(util.has_class_fixtures(C))
+        self.assertFalse(util.has_class_fixtures(C()))
+
+    def test_testcase_with_setup(self):
+        class C(unittest.TestCase):
+            @classmethod
+            def setUpClass(cls):
+                pass
+        self.assertTrue(util.has_class_fixtures(C))
+        self.assertTrue(util.has_class_fixtures(C()))
+
+    def test_testcase_with_teardown(self):
+        class C(unittest.TestCase):
+            @classmethod
+            def tearDownClass(cls):
+                pass
+        self.assertTrue(util.has_class_fixtures(C))
+        self.assertTrue(util.has_class_fixtures(C()))
+
+    def test_derived_derived_testcase(self):
+        class C(unittest.TestCase):
+            @classmethod
+            def setUpClass(cls):
+                pass
+            @classmethod
+            def tearDownClass(cls):
+                pass
+        class D(C):
+            pass
+        self.assertTrue(util.has_class_fixtures(D))
+        self.assertTrue(util.has_class_fixtures(D()))

--- a/nose2/tests/unit/test_util.py
+++ b/nose2/tests/unit/test_util.py
@@ -76,3 +76,56 @@ class HasClassFixturesTests(TestCase):
             pass
         self.assertTrue(util.has_class_fixtures(D))
         self.assertTrue(util.has_class_fixtures(D()))
+
+
+class HasModuleFixturesTests(TestCase):
+
+    def test_module_without_fixtures(self):
+        class M(object):
+            pass
+        M.__name__ = 'nose2.foo.bar'
+        class C(unittest.TestCase):
+            pass
+        C.__module__ = M.__name__
+        m = M()
+        m.C = C
+        sys.modules[M.__name__] = m
+        try:
+            self.assertFalse(util.has_module_fixtures(C))
+            self.assertFalse(util.has_module_fixtures(C()))
+        finally:
+            del sys.modules[M.__name__]
+
+    def test_module_with_setup(self):
+        class M(object):
+            pass
+        M.__name__ = 'nose2.foo.bar'
+        class C(unittest.TestCase):
+            pass
+        C.__module__ = M.__name__
+        m = M()
+        m.C = C
+        m.setUpModule = lambda: None
+        sys.modules[M.__name__] = m
+        try:
+            self.assertTrue(util.has_module_fixtures(C))
+            self.assertTrue(util.has_module_fixtures(C()))
+        finally:
+            del sys.modules[M.__name__]
+
+    def test_module_with_teardown(self):
+        class M(object):
+            pass
+        M.__name__ = 'nose2.foo.bar'
+        class C(unittest.TestCase):
+            pass
+        C.__module__ = M.__name__
+        m = M()
+        m.C = C
+        m.tearDownModule = lambda: None
+        sys.modules[M.__name__] = m
+        try:
+            self.assertTrue(util.has_module_fixtures(C))
+            self.assertTrue(util.has_module_fixtures(C()))
+        finally:
+            del sys.modules[M.__name__]

--- a/nose2/tests/unit/test_util.py
+++ b/nose2/tests/unit/test_util.py
@@ -37,6 +37,7 @@ class UtilTests(TestCase):
 
 class HasClassFixturesTests(TestCase):
 
+    @unittest.skipIf(sys.version_info < (3,), 'Python 3 required')
     def test_unittest_testcase(self):
         C = unittest.TestCase
         self.assertFalse(util.has_class_fixtures(C))
@@ -44,7 +45,8 @@ class HasClassFixturesTests(TestCase):
 
     def test_derived_testcase(self):
         class C(unittest.TestCase):
-            pass
+            def runTest(self):
+                pass
         self.assertFalse(util.has_class_fixtures(C))
         self.assertFalse(util.has_class_fixtures(C()))
 
@@ -53,6 +55,8 @@ class HasClassFixturesTests(TestCase):
             @classmethod
             def setUpClass(cls):
                 pass
+            def runTest(self):
+                pass
         self.assertTrue(util.has_class_fixtures(C))
         self.assertTrue(util.has_class_fixtures(C()))
 
@@ -60,6 +64,8 @@ class HasClassFixturesTests(TestCase):
         class C(unittest.TestCase):
             @classmethod
             def tearDownClass(cls):
+                pass
+            def runTest(self):
                 pass
         self.assertTrue(util.has_class_fixtures(C))
         self.assertTrue(util.has_class_fixtures(C()))
@@ -73,7 +79,8 @@ class HasClassFixturesTests(TestCase):
             def tearDownClass(cls):
                 pass
         class D(C):
-            pass
+            def runTest(self):
+                pass
         self.assertTrue(util.has_class_fixtures(D))
         self.assertTrue(util.has_class_fixtures(D()))
 
@@ -85,7 +92,8 @@ class HasModuleFixturesTests(TestCase):
             pass
         M.__name__ = 'nose2.foo.bar'
         class C(unittest.TestCase):
-            pass
+            def runTest(self):
+                pass
         C.__module__ = M.__name__
         m = M()
         m.C = C
@@ -101,7 +109,8 @@ class HasModuleFixturesTests(TestCase):
             pass
         M.__name__ = 'nose2.foo.bar'
         class C(unittest.TestCase):
-            pass
+            def runTest(self):
+                pass
         C.__module__ = M.__name__
         m = M()
         m.C = C
@@ -118,7 +127,8 @@ class HasModuleFixturesTests(TestCase):
             pass
         M.__name__ = 'nose2.foo.bar'
         class C(unittest.TestCase):
-            pass
+            def runTest(self):
+                pass
         C.__module__ = M.__name__
         m = M()
         m.C = C

--- a/nose2/util.py
+++ b/nose2/util.py
@@ -239,6 +239,8 @@ def has_module_fixtures(test):
 
 
 def has_class_fixtures(test):
+    # test may be class or instance
+    test_class = test if isinstance(test, type) else test.__class__
     # hasattr would be the obvious thing to use here. Unfortunately, all tests
     # inherit from unittest2.case.TestCase, and that *always* has setUpClass and
     # tearDownClass methods. Thus, exclude the unitest and unittest2 base
@@ -248,9 +250,9 @@ def has_class_fixtures(test):
             "unittest.case" not in c.__module__ and
             "unittest2.case" not in c.__module__)
     has_class_setups = any(
-        'setUpClass' in c.__dict__ for c in test.__class__.__mro__ if is_not_base_class(c))
+        'setUpClass' in c.__dict__ for c in test_class.__mro__ if is_not_base_class(c))
     has_class_teardowns = any(
-        'tearDownClass' in c.__dict__ for c in test.__class__.__mro__ if is_not_base_class(c))
+        'tearDownClass' in c.__dict__ for c in test_class.__mro__ if is_not_base_class(c))
     return has_class_setups or has_class_teardowns
 
 

--- a/nose2/util.py
+++ b/nose2/util.py
@@ -230,7 +230,9 @@ def isgenerator(obj):
 
 def has_module_fixtures(test):
     """Does this test live in a module with module fixtures?"""
-    modname = test.__class__.__module__
+    # test may be class or instance
+    test_class = test if isinstance(test, type) else test.__class__
+    modname = test_class.__module__
     try:
         mod = sys.modules[modname]
     except KeyError:


### PR DESCRIPTION
Refs #482

This is a big one and may require some explanation, so here we go:

1. Using @ltfish's #470 as a starting point I set out to see if I could make mp support test classes.
2. I make heavy use of my  [nose2-kflag](https://pypi.org/project/nose2-kflag/) plugin to only run tests I am currently working on, which made me notice that
3. The mp plugin handles `setUpModule` and `setUpClass` by augmenting the test suite to include the entire module or class, instead of just running the selected tests. See [mp._flatten](https://github.com/nose-devs/nose2/blob/8d153e5751771d13f8e691de2820582cc4045e14/nose2/plugins/mp.py#L242).
4. This in turn made me write a lot of tests for module and class fixtures to help me understand the details of what's going on.
5. During the course of which I noticed that the names of tests added by augmentation could not be displayed in error reports or when using -v. This is also true for test cases and not just test classes!
6. It also made me remove unnecessary `setUpModule` and `setUpClass` stubs in test classes and generators.
7. Getting test classes to work in the background also required changes to parameters and generators.

And this is how I ended up with 16 commits. 🤷‍♂️ 

Reviewers may want to go commit by commit instead of looking at the entire diff at once.

Cheers

