### PR TITLE
Avoid empty line before error list if verbosity is less than 1

### DIFF
--- a/nose2/plugins/result.py
+++ b/nose2/plugins/result.py
@@ -172,7 +172,8 @@ class ResultReporter(events.Plugin):
         errors = cats.get('errors', [])
         failures = cats.get('failures', [])
         # use evt.stream so plugins can replace/wrap/spy it
-        evt.stream.writeln('')
+        if self.session.verbosity > 0:
+            evt.stream.writeln('')
         self._printErrorList('ERROR', errors, evt.stream)
         self._printErrorList('FAIL', failures, evt.stream)
 

--- a/nose2/tests/functional/test_verbosity.py
+++ b/nose2/tests/functional/test_verbosity.py
@@ -1,13 +1,12 @@
 from nose2.tests._common import FunctionalTestCase
 
-_SUFFIX = (
-    "\n----------------------------------------------------------------------"
-    "\nRan 1 test "
-)
+_SUFFIX = """\
+----------------------------------------------------------------------
+Ran 1 test """
 
 Q_TEST_PATTERN = r"(?<!\.)(?<!ok)" + _SUFFIX
-MID_TEST_PATTERN = r"\." + _SUFFIX
-V_TEST_PATTERN = r"test \(__main__\.Test\) \.\.\. ok" + "\n" + _SUFFIX
+MID_TEST_PATTERN = r"\." + "\n" + _SUFFIX
+V_TEST_PATTERN = r"test \(__main__\.Test\) \.\.\. ok" + "\n\n" + _SUFFIX
 
 
 class TestVerbosity(FunctionalTestCase):


### PR DESCRIPTION
Fixes #486.