### PR TITLE
Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/nose2/plugins/loader/parameters.py
+++ b/nose2/plugins/loader/parameters.py
@@ -24,13 +24,13 @@ of the test function is the "case" argument, followed by the other parameters::
         @it.should('do bar')
         @params(1,2,3)
         def test(case, bar):
-            case.assert_(isinstance(bar, int))
+            case.assertTrue(isinstance(bar, int))
 
         @it.should('do bar and extra')
         @params((1, 2), (3, 4) ,(5, 6))
         def testExtraArg(case, bar, foo):
-            case.assert_(isinstance(bar, int))
-            case.assert_(isinstance(foo, int))
+            case.assertTrue(isinstance(bar, int))
+            case.assertTrue(isinstance(foo, int))
 
     it.createTests(globals())
 

--- a/nose2/tests/functional/support/scenario/layers_setups/higher_layer_setup.py
+++ b/nose2/tests/functional/support/scenario/layers_setups/higher_layer_setup.py
@@ -23,13 +23,13 @@ with such.A("foo") as it:
 
         @it.should("run all setups")
         def test_run_all_setups(case):
-            case.assertEquals(it.upper_run, 1)
-            case.assertEquals(it.lower_run, 1)
+            case.assertEqual(it.upper_run, 1)
+            case.assertEqual(it.lower_run, 1)
 
         @it.should("run all setups just once")
         def test_run_all_setups_just_once(case):
-            case.assertEquals(it.upper_run, 1)
-            case.assertEquals(it.lower_run, 1)
+            case.assertEqual(it.upper_run, 1)
+            case.assertEqual(it.lower_run, 1)
 
 
 it.createTests(globals())

--- a/nose2/tests/functional/support/scenario/layers_setups/higher_layer_testsetup_3layers.py
+++ b/nose2/tests/functional/support/scenario/layers_setups/higher_layer_testsetup_3layers.py
@@ -31,15 +31,15 @@ with such.A("foo") as it:
 
             @it.should("run all setups")
             def test_run_all_setups(case):
-                case.assertEquals(it.upper_run, 1)
-                case.assertEquals(it.mid_run, 1)
-                case.assertEquals(it.lower_run, 1)
+                case.assertEqual(it.upper_run, 1)
+                case.assertEqual(it.mid_run, 1)
+                case.assertEqual(it.lower_run, 1)
 
             @it.should("run all setups again")
             def test_run_all_setups_again(case):
-                case.assertEquals(it.upper_run, 2)
-                case.assertEquals(it.mid_run, 2)
-                case.assertEquals(it.lower_run, 2)
+                case.assertEqual(it.upper_run, 2)
+                case.assertEqual(it.mid_run, 2)
+                case.assertEqual(it.lower_run, 2)
 
 
 it.createTests(globals())

--- a/nose2/tests/functional/support/scenario/layers_setups/higher_layer_testsetup_no_test.py
+++ b/nose2/tests/functional/support/scenario/layers_setups/higher_layer_testsetup_no_test.py
@@ -23,13 +23,13 @@ with such.A("foo") as it:
 
         @it.should("run all setups")
         def test_run_all_setups(case):
-            case.assertEquals(it.upper_run, 1)
-            case.assertEquals(it.lower_run, 1)
+            case.assertEqual(it.upper_run, 1)
+            case.assertEqual(it.lower_run, 1)
 
         @it.should("run all setups again")
         def test_run_all_setups_again(case):
-            case.assertEquals(it.upper_run, 2)
-            case.assertEquals(it.lower_run, 2)
+            case.assertEqual(it.upper_run, 2)
+            case.assertEqual(it.lower_run, 2)
 
 
 it.createTests(globals())

--- a/nose2/tests/functional/support/scenario/layers_setups/higher_layer_testsetup_with_test.py
+++ b/nose2/tests/functional/support/scenario/layers_setups/higher_layer_testsetup_with_test.py
@@ -16,8 +16,8 @@ with such.A("foo") as it:
 
     @it.should("run upper setups")
     def test_run_upper_setups(case):
-        case.assertEquals(it.upper_run, 1)
-        case.assertEquals(it.lower_run, 0)
+        case.assertEqual(it.upper_run, 1)
+        case.assertEqual(it.lower_run, 0)
 
     with it.having("some bar"):
 
@@ -28,13 +28,13 @@ with such.A("foo") as it:
 
         @it.should("run all setups")
         def test_run_all_setups(case):
-            case.assertEquals(it.upper_run, 2)
-            case.assertEquals(it.lower_run, 1)
+            case.assertEqual(it.upper_run, 2)
+            case.assertEqual(it.lower_run, 1)
 
         @it.should("run all setups again")
         def test_run_all_setups_again(case):
-            case.assertEquals(it.upper_run, 3)
-            case.assertEquals(it.lower_run, 2)
+            case.assertEqual(it.upper_run, 3)
+            case.assertEqual(it.lower_run, 2)
 
 
 it.createTests(globals())

--- a/nose2/tests/functional/support/scenario/logging/logging_keeps_copies_of_mutable_objects.py
+++ b/nose2/tests/functional/support/scenario/logging/logging_keeps_copies_of_mutable_objects.py
@@ -11,7 +11,7 @@ class Test(unittest.TestCase):
         d = {}
         log.debug("foo: %s", d)
         d["bar"] = "baz"
-        self.assert_(False)
+        self.assertTrue(False)
 
 
 if __name__ == "__main__":

--- a/nose2/tests/functional/support/scenario/such_with_params/such_with_params.py
+++ b/nose2/tests/functional/support/scenario/such_with_params/such_with_params.py
@@ -6,13 +6,13 @@ with such.A("foo") as it:
     @it.should("do bar")
     @params(1, 2, 3)
     def test(case, bar):
-        case.assert_(isinstance(bar, int))
+        case.assertTrue(isinstance(bar, int))
 
     @it.should("do bar and extra")
     @params((1, 2), (3, 4), (5, 6))
     def testExtraArg(case, bar, foo):
-        case.assert_(isinstance(bar, int))
-        case.assert_(isinstance(foo, int))
+        case.assertTrue(isinstance(bar, int))
+        case.assertTrue(isinstance(foo, int))
 
 
 it.createTests(globals())

--- a/nose2/tests/unit/test_decorators.py
+++ b/nose2/tests/unit/test_decorators.py
@@ -17,7 +17,7 @@ class WithSetupDecoratorTests(TestCase):
         sut = self.fake_test()
         expected = with_setup(self.fake_setup)(sut).setup
 
-        self.assertEquals(expected, self.fake_setup)
+        self.assertEqual(expected, self.fake_setup)
 
 
 class WithTeardownDecoratorTests(TestCase):
@@ -31,4 +31,4 @@ class WithTeardownDecoratorTests(TestCase):
         sut = self.fake_test()
         expected = with_teardown(self.fake_teardown)(sut).tearDownFunc
 
-        self.assertEquals(expected, self.fake_teardown)
+        self.assertEqual(expected, self.fake_teardown)


### PR DESCRIPTION
Deprecated unittest aliases were removed in Python 3.11 . This will cause error when tests are executed in Python 3.11 .

Ref : python/cpython#28268