### PR TITLE
add timestamp support to junitxml plugin

### DIFF
--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -39,16 +39,16 @@ Produces this XML by default:
 
 .. code-block:: xml
 
-    <testcase classname="a" name="test_gen:1" time="0.000171">
+    <testcase classname="a" name="test_gen:1" time="0.000171" timestamp="2021-12-09T21:28:09.686611">
         <system-out />
     </testcase>
-    <testcase classname="a" name="test_gen:2" time="0.000202">
+    <testcase classname="a" name="test_gen:2" time="0.000202" timestamp="2021-12-09T21:28:09.686813">
         <system-out />
     </testcase>
-    <testcase classname="a" name="test_params:1" time="0.000159">
+    <testcase classname="a" name="test_params:1" time="0.000159" timestamp="2021-12-09T21:28:09.686972">
         <system-out />
     </testcase>
-    <testcase classname="a" name="test_params:2" time="0.000163">
+    <testcase classname="a" name="test_params:2" time="0.000163" timestamp="2021-12-09T21:28:09.687135">
         <system-out />
     </testcase>
 
@@ -57,16 +57,16 @@ produced:
 
 .. code-block:: xml
 
-    <testcase classname="a" name="test_gen:1 (99, 99)" time="0.000213">
+    <testcase classname="a" name="test_gen:1 (99, 99)" time="0.000213" timestamp="2021-12-09T21:28:09.686611">
         <system-out />
     </testcase>
-    <testcase classname="a" name="test_gen:2 (-1, -1)" time="0.000194">
+    <testcase classname="a" name="test_gen:2 (-1, -1)" time="0.000194" timestamp="2021-12-09T21:28:09.687105">
         <system-out />
     </testcase>
-    <testcase classname="a" name="test_params:1 ('foo')" time="0.000178">
+    <testcase classname="a" name="test_params:1 ('foo')" time="0.000178" timestamp="2021-12-09T21:28:09.687283">
         <system-out />
     </testcase>
-    <testcase classname="a" name="test_params:2 ('bar')" time="0.000187">
+    <testcase classname="a" name="test_params:2 ('bar')" time="0.000187" timestamp="2021-12-09T21:28:09.687470">
         <system-out />
     </testcase>
 
@@ -79,6 +79,7 @@ import os.path
 import re
 import sys
 import time
+import datetime
 from xml.etree import ElementTree as ET
 
 import six
@@ -152,6 +153,8 @@ class JUnitXmlReporter(events.Plugin):
             return
 
         testcase = ET.SubElement(self.tree, "testcase")
+        testcase.set('timestamp',
+                     str(self._timestamp_to_iso8601(self._start)))
         testcase.set("time", "%.6f" % self._time())
         if not classname:
             classname = test.__module__
@@ -285,6 +288,8 @@ class JUnitXmlReporter(events.Plugin):
             self._start = None
         return 0
 
+    def _timestamp_to_iso8601(self, timestamp):
+        return datetime.datetime.utcfromtimestamp(timestamp).isoformat()
 
 #
 # xml utility functions

--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -289,7 +289,10 @@ class JUnitXmlReporter(events.Plugin):
         return 0
 
     def _timestamp_to_iso8601(self, timestamp):
-        return datetime.datetime.utcfromtimestamp(timestamp).isoformat()
+        try:
+            return datetime.datetime.utcfromtimestamp(timestamp).isoformat()
+        except Exception:
+            return datetime.datetime.utcfromtimestamp(0).isoformat()
 
 #
 # xml utility functions

--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -39,16 +39,20 @@ Produces this XML by default:
 
 .. code-block:: xml
 
-    <testcase classname="a" name="test_gen:1" time="0.000171" timestamp="2021-12-09T21:28:09.686611">
+    <testcase classname="a" name="test_gen:1" time="0.000171"
+     timestamp="2021-12-09T21:28:09.686611">
         <system-out />
     </testcase>
-    <testcase classname="a" name="test_gen:2" time="0.000202" timestamp="2021-12-09T21:28:09.686813">
+    <testcase classname="a" name="test_gen:2" time="0.000202"
+     timestamp="2021-12-09T21:28:09.686813">
         <system-out />
     </testcase>
-    <testcase classname="a" name="test_params:1" time="0.000159" timestamp="2021-12-09T21:28:09.686972">
+    <testcase classname="a" name="test_params:1" time="0.000159"
+     timestamp="2021-12-09T21:28:09.686972">
         <system-out />
     </testcase>
-    <testcase classname="a" name="test_params:2" time="0.000163" timestamp="2021-12-09T21:28:09.687135">
+    <testcase classname="a" name="test_params:2" time="0.000163"
+     timestamp="2021-12-09T21:28:09.687135">
         <system-out />
     </testcase>
 
@@ -57,16 +61,20 @@ produced:
 
 .. code-block:: xml
 
-    <testcase classname="a" name="test_gen:1 (99, 99)" time="0.000213" timestamp="2021-12-09T21:28:09.686611">
+    <testcase classname="a" name="test_gen:1 (99, 99)" time="0.000213"
+     timestamp="2021-12-09T21:28:09.686611">
         <system-out />
     </testcase>
-    <testcase classname="a" name="test_gen:2 (-1, -1)" time="0.000194" timestamp="2021-12-09T21:28:09.687105">
+    <testcase classname="a" name="test_gen:2 (-1, -1)" time="0.000194"
+     timestamp="2021-12-09T21:28:09.687105">
         <system-out />
     </testcase>
-    <testcase classname="a" name="test_params:1 ('foo')" time="0.000178" timestamp="2021-12-09T21:28:09.687283">
+    <testcase classname="a" name="test_params:1 ('foo')" time="0.000178"
+     timestamp="2021-12-09T21:28:09.687283">
         <system-out />
     </testcase>
-    <testcase classname="a" name="test_params:2 ('bar')" time="0.000187" timestamp="2021-12-09T21:28:09.687470">
+    <testcase classname="a" name="test_params:2 ('bar')" time="0.000187"
+     timestamp="2021-12-09T21:28:09.687470">
         <system-out />
     </testcase>
 

--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -82,12 +82,12 @@ produced:
 # Based on unittest2/plugins/junitxml.py,
 # which is itself based on the junitxml plugin from py.test
 
+import datetime
 import json
 import os.path
 import re
 import sys
 import time
-import datetime
 from xml.etree import ElementTree as ET
 
 import six
@@ -161,8 +161,7 @@ class JUnitXmlReporter(events.Plugin):
             return
 
         testcase = ET.SubElement(self.tree, "testcase")
-        testcase.set('timestamp',
-                     str(self._timestamp_to_iso8601(self._start)))
+        testcase.set("timestamp", str(self._timestamp_to_iso8601(self._start)))
         testcase.set("time", "%.6f" % self._time())
         if not classname:
             classname = test.__module__
@@ -301,6 +300,7 @@ class JUnitXmlReporter(events.Plugin):
             return datetime.datetime.utcfromtimestamp(timestamp).isoformat()
         except Exception:
             return datetime.datetime.utcfromtimestamp(0).isoformat()
+
 
 #
 # xml utility functions

--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -161,7 +161,7 @@ class JUnitXmlReporter(events.Plugin):
             return
 
         testcase = ET.SubElement(self.tree, "testcase")
-        testcase.set("timestamp", str(self._timestamp_to_iso8601(self._start)))
+        testcase.set("timestamp", self._iso_timestamp())
         testcase.set("time", "%.6f" % self._time())
         if not classname:
             classname = test.__module__
@@ -295,11 +295,11 @@ class JUnitXmlReporter(events.Plugin):
             self._start = None
         return 0
 
-    def _timestamp_to_iso8601(self, timestamp):
-        try:
-            return datetime.datetime.utcfromtimestamp(timestamp).isoformat()
-        except Exception:
-            return datetime.datetime.utcfromtimestamp(0).isoformat()
+    def _iso_timestamp(self):
+        # in some cases, `self._start` is still None when this runs, convert to 0
+        # see: https://github.com/nose-devs/nose2/pull/505
+        timestamp = self._start or 0
+        return str(datetime.datetime.utcfromtimestamp(timestamp).isoformat())
 
 
 #

--- a/nose2/tests/unit/test_junitxml.py
+++ b/nose2/tests/unit/test_junitxml.py
@@ -1,9 +1,9 @@
+import datetime
 import logging
 import os
 import sys
 import unittest
 from xml.etree import ElementTree as ET
-import datetime
 
 import six
 

--- a/nose2/tests/unit/test_junitxml.py
+++ b/nose2/tests/unit/test_junitxml.py
@@ -13,6 +13,14 @@ from nose2.plugins.loader import functions, generators, parameters, testcases
 from nose2.tests._common import TestCase
 
 
+def _fromisoformat(date_str):
+    # use fromisoformat when it is available, but failover to strptime for python2 and
+    # older python3 versions
+    if hasattr(datetime.datetime, "fromisoformat"):
+        return datetime.datetime.fromisoformat(date_str)
+    return datetime.datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S.%f")
+
+
 class TestJunitXmlPlugin(TestCase):
     _RUN_IN_TEMP = True
 
@@ -205,9 +213,9 @@ class TestJunitXmlPlugin(TestCase):
         xml = self.plugin.tree.findall("testcase")
         self.assertEqual(len(xml), 2)
         test1_timestamp_str = xml[0].get("timestamp")
-        test1_timestamp = datetime.datetime.fromisoformat(test1_timestamp_str)
+        test1_timestamp = _fromisoformat(test1_timestamp_str)
         test2_timestamp_str = xml[1].get("timestamp")
-        test2_timestamp = datetime.datetime.fromisoformat(test2_timestamp_str)
+        test2_timestamp = _fromisoformat(test2_timestamp_str)
         self.assertGreater(test2_timestamp, test1_timestamp)
 
     def test_generator_test_name_correct(self):


### PR DESCRIPTION
Per [spec definition](https://github.com/junit-team/junit5/blob/86b6b85/platform-tests/src/test/resources/jenkins-junit.xsd), junit-xml can have timestamp support (or the closest thing we have to a spec).
This adds that support, following the timestamp string definition according to the [date and time ISO 8601 standard](https://www.iso.org/iso-8601-date-and-time-format.html).

Regarding the choice of timestamp formatting, there doesn't seem to be an authoritative source on the spec, but in [this thread](https://stackoverflow.com/questions/442556/spec-for-junit-xml-output) people suggest Apache Ant project responsible for implementing the spec. In their implementation we see [the use of the ISO standard](https://github.com/apache/ant/blob/3a4980e/src/main/org/apache/tools/ant/taskdefs/optional/junit/XMLJUnitResultFormatter.java#L141):

```java
        //add the timestamp
        final String timestamp = DateUtils.format(new Date(),
                DateUtils.ISO8601_DATETIME_PATTERN);
        rootElement.setAttribute(TIMESTAMP, timestamp);
```

Pytest's junitxml implementation [also uses timestamps](https://docs.pytest.org/en/6.2.x/_modules/_pytest/junitxml.html) and their implementation (again) [uses the date and time ISO format](https://github.com/pytest-dev/pytest/blob/062d91a/src/_pytest/junitxml.py#L669).