### PR TITLE
Update docs to note support for py2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,12 +128,34 @@ Full Docs
 
 Full documentation for ``nose2`` is available at `docs.nose2.io`_
 
+Versions and Support
+--------------------
+
+Changelog and Version Scheme
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+nose2 versions are numbered `0.MAJOR.MINOR`. Minor releases contain bugfixes or
+smaller features. Major features or backwards incompatible changes are done in
+major releases.
+
+For a full description of all past versions and changes, see the `changelog`_.
+
+Python Versions
+~~~~~~~~~~~~~~~
+
+nose2 supports all currently supported python versions.
+
+It also will continue to support python2 for as long as it remains feasible and
+a significant percentage of nose2 users are using python2.
+
 Contributing
 ------------
 
 If you want to make contributions, please read the `contributing`_ guide.
 
-.. _differences: https://nose2.readthedocs.io/en/latest/differences.html
+.. _differences: https://docs.nose2.io/en/latest/differences.html
+
+.. _changelog: https://docs.nose2.io/en/latest/changelog.html
 
 .. _pytest: http://pytest.readthedocs.io/en/latest/
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,12 @@ Changelog
 nose2 uses semantic versioning (currently in 0.x) and the popular
 "keep a changelog" format (v1.0.0).
 
+nose2 tries not to break backwards compatibility in any release. Until v1.0,
+versions are numbered `0.MAJOR.MINOR`. Major releases introduce new
+functionality or contain necessary breaking changes. Minor releases are
+primarily used for bugfix or small features which are unlikely to break users'
+testsuites.
+
 0.10.0 (2020-01-27)
 -------------------
 
@@ -45,8 +51,6 @@ Fixed
 
 * Class methods decorated (e.g. with ``mock.patch``) are no longer incorrectly
   picked up by the function loader
-
-    Merge pull request #485 from stefanholek/484-session-plugin-registry
 
 0.9.2 (2020-02-02)
 ------------------


### PR DESCRIPTION
Also include some notes on versioning, while trying to avoid murky waters around the 0.x versioning and "semantic versioning".

resolves #481