### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,7 @@ jobs:
           nose2 -v --pretty-assert
   test:
     strategy:
+      fail-fast: false
       matrix:
         # for the matrix, macos and linux on
         #   - py2
@@ -36,24 +37,26 @@ jobs:
         # any additional builds for windows and other python versions are
         # handled via `include` to avoid an over-large test matrix
         os: [ubuntu-latest, macos-latest]
-        python-version: [2.7, 3.5, 3.9]
+        python-version: ["2.7", "3.5", "3.10"]
         include:
           - os: ubuntu-latest
-            python-version: 3.6
+            python-version: "3.6"
           - os: ubuntu-latest
-            python-version: 3.7
+            python-version: "3.7"
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.8"
           - os: ubuntu-latest
-            python-version: pypy-2.7
+            python-version: "3.9"
           - os: ubuntu-latest
-            python-version: pypy-3.7
+            python-version: "pypy-2.7"
+          - os: ubuntu-latest
+            python-version: "pypy-3.7"
           # FIXME: windows builds fail and must therefore be included with
           # `ignore-failures: true` which we pass for `continue-on-error` below
           - os: windows-latest
-            python-version: 2.7
+            python-version: "2.7"
           - os: windows-latest
-            python-version: 3.9
+            python-version: "3.10"
     name: "python=${{ matrix.python-version }} os=${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -65,13 +68,13 @@ jobs:
         run: python -m pip install -U tox
       - name: lint
         run: python -m tox -e lint
-        # only lint on linux py39 box for faster overall builds
-        if: ${{ matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest' }}
+        # only lint on linux py3 box for faster overall builds
+        if: ${{ matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest' }}
       - name: test
         run: python -m tox -e py
         # ignore errors in windows builds (for now)
         continue-on-error: ${{ matrix.os == 'windows-latest' }}
       - name: ensure docs build
         # docs are only ever built on a linux py3 box (readthedocs)
-        if: ${{ matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest' }}
         run: python -m tox -e docs

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py35,py36,py37,pypy,pypy3,docs,lint
+envlist=py27,py35,py36,py37,py38,py39,py310,pypy,pypy3,docs,lint
 
 [testenv]
 extras = dev


### PR DESCRIPTION
Python 3.10 was released on 2021-10-04:

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955