### PR TITLE
Test on py3.11-dev and drop py35 from testing and classifiers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,33 +29,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # for the matrix, macos and linux on
-        #   - py2
-        #   - the lowest supported py3
-        #   - the highest supported py3
+        # for the matrix, linux on all pythons
         #
-        # any additional builds for windows and other python versions are
+        # any additional builds for windows and macos
         # handled via `include` to avoid an over-large test matrix
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["2.7", "3.5", "3.10"]
+        os: [ubuntu-latest]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11-dev", "pypy-2.7", "pypy-3.7"]
         include:
-          - os: ubuntu-latest
-            python-version: "3.6"
-          - os: ubuntu-latest
-            python-version: "3.7"
-          - os: ubuntu-latest
-            python-version: "3.8"
-          - os: ubuntu-latest
-            python-version: "3.9"
-          - os: ubuntu-latest
-            python-version: "pypy-2.7"
-          - os: ubuntu-latest
-            python-version: "pypy-3.7"
-          # FIXME: windows builds fail and must therefore be included with
-          # `ignore-failures: true` which we pass for `continue-on-error` below
           - os: windows-latest
             python-version: "2.7"
           - os: windows-latest
+            python-version: "3.10"
+          - os: macos-latest
+            python-version: "2.7"
+          - os: macos-latest
             python-version: "3.10"
     name: "python=${{ matrix.python-version }} os=${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -72,7 +59,7 @@ jobs:
         if: ${{ matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest' }}
       - name: test
         run: python -m tox -e py
-        # ignore errors in windows builds (for now)
+        # FIXME: ignore errors in windows builds (for now)
         continue-on-error: ${{ matrix.os == 'windows-latest' }}
       - name: ensure docs build
         # docs are only ever built on a linux py3 box (readthedocs)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     - id: check-merge-conflict
     - id: trailing-whitespace
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.3.0
+  rev: 0.10.2
   hooks:
     - id: check-github-workflows
 - repo: https://github.com/python/black

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,6 @@ setup(
     install_requires=[
         "six>=1.7",
         "coverage>=4.4.1",
-        # mock on py2, py3.4 and py3.5
-        # not just py2: py3 versions of mock don't all have the same
-        # interface and this can cause issues
-        'mock==2.0.0;python_version<"3.6"',
     ],
     extras_require={
         "coverage_plugin": ["coverage>=4.4.1"],
@@ -55,7 +51,6 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py35,py36,py37,py38,py39,py310,pypy,pypy3,docs,lint
+envlist=py{27,36,37,38,39,310,311},pypy,pypy3,docs,lint
 
 [testenv]
 extras = dev


### PR DESCRIPTION
This should resolve #501. There's a fix to the tests for that issue, and tests will now run on 3.11-dev.

Doing this as a PR to ensure that CI changes are put through their paces.