### PR TITLE
Update github, tox, and RTD configs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: "3.10"
       - name: test
         run: |
           python setup.py sdist
@@ -25,6 +25,7 @@ jobs:
           cd "nose2-${version}"
           pip install -e '.[dev]'
           nose2 -v --pretty-assert
+
   test:
     strategy:
       fail-fast: false
@@ -53,15 +54,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: install tox
         run: python -m pip install -U tox
-      - name: lint
-        run: python -m tox -e lint
-        # only lint on linux py3 box for faster overall builds
-        if: ${{ matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest' }}
       - name: test
         run: python -m tox -e py
         # FIXME: ignore errors in windows builds (for now)
         continue-on-error: ${{ matrix.os == 'windows-latest' }}
-      - name: ensure docs build
-        # docs are only ever built on a linux py3 box (readthedocs)
-        if: ${{ matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest' }}
-        run: python -m tox -e docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,16 @@
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - dev

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ skip_install = true
 commands = pre-commit run --all-files
 
 [testenv:docs]
-basepython=python2.7
 extras = dev
 changedir=docs
 commands=sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html


### PR DESCRIPTION
Improve CI build matrices.
Drop docs from github CI build. We'll use the readthedocs CI to build on pull requests.

This PR should confirm that the new RTD config works.