### PR TITLE
Re-enable Windows CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,5 +56,3 @@ jobs:
         run: python -m pip install -U tox
       - name: test
         run: python -m tox -e py
-        # FIXME: ignore errors in windows builds (for now)
-        continue-on-error: ${{ matrix.os == 'windows-latest' }}

--- a/nose2/tests/_common.py
+++ b/nose2/tests/_common.py
@@ -1,5 +1,6 @@
 """Common functionality."""
 import os.path
+import platform
 import shutil
 import subprocess
 import sys
@@ -295,3 +296,16 @@ class Conn(object):
 
     def close(self):
         self.closed = True
+
+
+# true on GitHub Actions, false otherwise
+def environment_is_ci():
+    return os.getenv("CI") == "true"
+
+
+# special skip decorator for tests which are broken in Windows in CI
+def windows_ci_skip(f):
+    return unittest.skipIf(
+        platform.system() == "Windows" and environment_is_ci(),
+        "This test is skipped on Windows in CI",
+    )(f)

--- a/nose2/tests/functional/test_coverage.py
+++ b/nose2/tests/functional/test_coverage.py
@@ -4,7 +4,7 @@ import platform
 import sys
 import unittest
 
-from nose2.tests._common import FunctionalTestCase, support_file
+from nose2.tests._common import FunctionalTestCase, support_file, windows_ci_skip
 
 
 class TestCoverage(FunctionalTestCase):
@@ -68,6 +68,7 @@ class TestCoverage(FunctionalTestCase):
         platform.system() == "Darwin" and sys.version_info >= (3, 8),
         "FIXME: this test fails on modern pythons on macos",
     )
+    @windows_ci_skip
     def test_run_with_mp(self):
         # this test needs to be done with nose2 config because (as of 2019-12)
         # multiprocessing does not allow each test process to pick up on

--- a/nose2/tests/functional/test_prettyassert.py
+++ b/nose2/tests/functional/test_prettyassert.py
@@ -1,6 +1,6 @@
 import sys
 
-from nose2.tests._common import FunctionalTestCase
+from nose2.tests._common import FunctionalTestCase, windows_ci_skip
 
 # detect if DEBUG_RANGES are enabled in the interpreter
 #
@@ -141,6 +141,7 @@ class TestPrettyAsserts(FunctionalTestCase):
         )
         self.assertProcOutputPattern(proc, expected)
 
+    @windows_ci_skip
     def test_assert_attribute_resolution2(self):
         proc = self.runIn(
             "scenario/pretty_asserts/attribute_resolution2", "-v", "--pretty-assert"

--- a/nose2/tests/functional/test_verbosity.py
+++ b/nose2/tests/functional/test_verbosity.py
@@ -1,4 +1,4 @@
-from nose2.tests._common import FunctionalTestCase
+from nose2.tests._common import FunctionalTestCase, windows_ci_skip
 
 _SUFFIX = """\
 ----------------------------------------------------------------------
@@ -10,18 +10,22 @@ V_TEST_PATTERN = r"test \(__main__\.Test\) \.\.\. ok" + "\n\n" + _SUFFIX
 
 
 class TestVerbosity(FunctionalTestCase):
+    @windows_ci_skip
     def test_no_modifier(self):
         proc = self.runModuleAsMain("scenario/one_test/tests.py")
         self.assertTestRunOutputMatches(proc, stderr=MID_TEST_PATTERN)
 
+    @windows_ci_skip
     def test_one_v(self):
         proc = self.runModuleAsMain("scenario/one_test/tests.py", "-v")
         self.assertTestRunOutputMatches(proc, stderr=V_TEST_PATTERN)
 
+    @windows_ci_skip
     def test_one_q(self):
         proc = self.runModuleAsMain("scenario/one_test/tests.py", "-q")
         self.assertTestRunOutputMatches(proc, stderr=Q_TEST_PATTERN)
 
+    @windows_ci_skip
     def test_one_q_one_v(self):
         proc = self.runModuleAsMain("scenario/one_test/tests.py", "-q", "-v")
         self.assertTestRunOutputMatches(proc, stderr=MID_TEST_PATTERN)
@@ -29,6 +33,7 @@ class TestVerbosity(FunctionalTestCase):
         proc = self.runModuleAsMain("scenario/one_test/tests.py", "-qv")
         self.assertTestRunOutputMatches(proc, stderr=MID_TEST_PATTERN)
 
+    @windows_ci_skip
     def test_one_q_two_vs(self):
         proc = self.runModuleAsMain("scenario/one_test/tests.py", "-q", "-v", "-v")
         self.assertTestRunOutputMatches(proc, stderr=V_TEST_PATTERN)
@@ -36,6 +41,7 @@ class TestVerbosity(FunctionalTestCase):
         proc = self.runModuleAsMain("scenario/one_test/tests.py", "-qvv")
         self.assertTestRunOutputMatches(proc, stderr=V_TEST_PATTERN)
 
+    @windows_ci_skip
     def test_one_v_two_qs(self):
         proc = self.runModuleAsMain("scenario/one_test/tests.py", "-v", "-q", "-q")
         self.assertTestRunOutputMatches(proc, stderr=Q_TEST_PATTERN)
@@ -43,6 +49,7 @@ class TestVerbosity(FunctionalTestCase):
         proc = self.runModuleAsMain("scenario/one_test/tests.py", "-vqq")
         self.assertTestRunOutputMatches(proc, stderr=Q_TEST_PATTERN)
 
+    @windows_ci_skip
     def test_explicit_verbosity(self):
         proc = self.runModuleAsMain("scenario/one_test/tests.py", "--verbosity", "0")
         self.assertTestRunOutputMatches(proc, stderr=Q_TEST_PATTERN)
@@ -56,6 +63,7 @@ class TestVerbosity(FunctionalTestCase):
         proc = self.runModuleAsMain("scenario/one_test/tests.py", "--verbosity", "-1")
         self.assertTestRunOutputMatches(proc, stderr=Q_TEST_PATTERN)
 
+    @windows_ci_skip
     def test_tweaked_explicit_verbosity(self):
         proc = self.runModuleAsMain(
             "scenario/one_test/tests.py", "--verbosity", "0", "-vv"

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist=py{27,36,37,38,39,310,311},pypy,pypy3,docs,lint
 
 [testenv]
+passenv = CI
 extras = dev
 setenv = PYTHONPATH={toxinidir}
 commands =


### PR DESCRIPTION
Add special skip decorator to skip specific tests which aren't working in CI, and re-enable Windows testing.