### PR TITLE
Fix for additional test method name on Python 3.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.orig
 example.cfg
 .coverage
+.idea
 nosetests.xml
 xunit.xml
 nose2-junit.xml

--- a/nose2/tests/_common.py
+++ b/nose2/tests/_common.py
@@ -275,7 +275,7 @@ class RedirectStdStreams(object):
         sys.stderr = self.old_stderr
 
 
-# mock multprocessing Connection
+# mock multiprocessing Connection
 class Conn(object):
     def __init__(self, items):
         self.items = items
@@ -308,3 +308,9 @@ def windows_ci_skip(f):
         platform.system() == "Windows" and environment_is_ci(),
         "This test is skipped on Windows in CI",
     )(f)
+
+
+def _method_name(name="test"):
+    """Get an extra method name for Python 3.11"""
+    # https://github.com/python/cpython/issues/58473
+    return r"\." + name if sys.version_info >= (3, 11) else ""

--- a/nose2/tests/functional/test_junitxml_plugin.py
+++ b/nose2/tests/functional/test_junitxml_plugin.py
@@ -1,7 +1,7 @@
 import os
 from xml.etree import ElementTree as ET
 
-from nose2.tests._common import FunctionalTestCase, TestCase, support_file
+from nose2.tests._common import FunctionalTestCase, TestCase, _method_name, support_file
 
 
 class JunitXmlPluginFunctionalTest(FunctionalTestCase, TestCase):
@@ -34,7 +34,10 @@ class JunitXmlPluginFunctionalTest(FunctionalTestCase, TestCase):
         )
 
         self.assertTestRunOutputMatches(
-            proc, stderr=r"test \(test_junitxml_happyday.Test\) ... ok"
+            proc,
+            stderr=r"test \(test_junitxml_happyday.Test"
+            + _method_name()
+            + r"\) ... ok",
         )
         self.assertTestRunOutputMatches(proc, stderr="Ran 1 test")
         self.assertEqual(proc.poll(), 0)
@@ -51,7 +54,10 @@ class JunitXmlPluginFunctionalTest(FunctionalTestCase, TestCase):
         )
 
         self.assertTestRunOutputMatches(
-            proc, stderr=r"test \(test_junitxml_happyday.Test\) ... ok"
+            proc,
+            stderr=r"test \(test_junitxml_happyday.Test"
+            + _method_name()
+            + r"\) ... ok",
         )
         self.assertTestRunOutputMatches(proc, stderr="Ran 1 test")
         self.assertEqual(proc.poll(), 0)
@@ -68,7 +74,10 @@ class JunitXmlPluginFunctionalTest(FunctionalTestCase, TestCase):
         )
 
         self.assertTestRunOutputMatches(
-            proc, stderr=r"test \(test_junitxml_happyday.Test\) ... ok"
+            proc,
+            stderr=r"test \(test_junitxml_happyday.Test"
+            + _method_name()
+            + r"\) ... ok",
         )
         self.assertTestRunOutputMatches(proc, stderr="Ran 1 test")
         self.assertEqual(proc.poll(), 0)
@@ -85,7 +94,10 @@ class JunitXmlPluginFunctionalTest(FunctionalTestCase, TestCase):
         )
 
         self.assertTestRunOutputMatches(
-            proc, stderr=r"test_chdir \(test_junitxml_chdir.Test\) \.* ok"
+            proc,
+            stderr=r"test_chdir \(test_junitxml_chdir.Test"
+            + _method_name("test_chdir")
+            + r"\) \.* ok",
         )
         self.assertTestRunOutputMatches(proc, stderr="Ran 1 test")
         self.assertEqual(proc.poll(), 0)
@@ -104,7 +116,10 @@ class JunitXmlPluginFunctionalTest(FunctionalTestCase, TestCase):
             ("scenario", "junitxml", "with_properties"), "--junit-xml"
         )
         self.assertTestRunOutputMatches(
-            proc, stderr=r"test \(test_junitxml_with_properties.Test\) \.* ok"
+            proc,
+            stderr=r"test \(test_junitxml_with_properties.Test"
+            + _method_name()
+            + r"\) \.* ok",
         )
         self.assertEqual(proc.poll(), 0)
 
@@ -123,7 +138,10 @@ class JunitXmlPluginFunctionalTest(FunctionalTestCase, TestCase):
         )
 
         self.assertTestRunOutputMatches(
-            proc, stderr=r"test \(test_junitxml_skip_reason.Test\) \.* skip"
+            proc,
+            stderr=r"test \(test_junitxml_skip_reason.Test"
+            + _method_name()
+            + r"\) \.* skip",
         )
 
         exit_status = proc.poll()
@@ -150,7 +168,10 @@ class JunitXmlPluginFunctionalTest(FunctionalTestCase, TestCase):
         )
 
         self.assertTestRunOutputMatches(
-            proc, stderr=r"test \(test_junitxml_non_default_path.Test\) \.* ok"
+            proc,
+            stderr=r"test \(test_junitxml_non_default_path.Test"
+            + _method_name()
+            + r"\) \.* ok",
         )
 
         exit_status = proc.poll()
@@ -167,7 +188,10 @@ class JunitXmlPluginFunctionalTest(FunctionalTestCase, TestCase):
         )
 
         self.assertTestRunOutputMatches(
-            proc, stderr=r"test \(test_junitxml_non_default_path.Test\) \.* ok"
+            proc,
+            stderr=r"test \(test_junitxml_non_default_path.Test"
+            + _method_name()
+            + r"\) \.* ok",
         )
 
         exit_status = proc.poll()
@@ -187,7 +211,10 @@ class JunitXmlPluginFunctionalFailureTest(FunctionalTestCase, TestCase):
         self.assertEqual(proc.poll(), 1)
 
         self.assertTestRunOutputMatches(
-            proc, stderr=r"test \(test_junitxml_fail_to_write.Test\) \.* ok"
+            proc,
+            stderr=r"test \(test_junitxml_fail_to_write.Test"
+            + _method_name()
+            + r"\) \.* ok",
         )
 
         filename_for_regex = os.path.abspath("/does/not/exist.xml")
@@ -209,7 +236,10 @@ class JunitXmlPluginFunctionalFailureTest(FunctionalTestCase, TestCase):
         self.assertEqual(proc.poll(), 1)
 
         self.assertTestRunOutputMatches(
-            proc, stderr=r"test \(test_junitxml_missing_properties.Test\) \.* ok"
+            proc,
+            stderr=r"test \(test_junitxml_missing_properties.Test"
+            + _method_name()
+            + r"\) \.* ok",
         )
 
         filename_for_regex = os.path.join("missing_properties", "properties.json")
@@ -231,7 +261,10 @@ class JunitXmlPluginFunctionalFailureTest(FunctionalTestCase, TestCase):
         self.assertEqual(proc.poll(), 1)
 
         self.assertTestRunOutputMatches(
-            proc, stderr=r"test \(test_junitxml_empty_properties.Test\) \.* ok"
+            proc,
+            stderr=r"test \(test_junitxml_empty_properties.Test"
+            + _method_name()
+            + r"\) \.* ok",
         )
 
         filename_for_regex = os.path.join("empty_properties", "properties.json")

--- a/nose2/tests/functional/test_layers_hooks.py
+++ b/nose2/tests/functional/test_layers_hooks.py
@@ -23,7 +23,17 @@ class TestLayerHooks(FunctionalTestCase):
             "--plugin=layer_hooks_plugin",
             "test_simple_such",
         )
-        expected = r"""^StartLayerSetup: <class 'test_simple_such.A system:layer'>
+        if sys.version_info >= (3, 11):
+            expected = r"""^StartLayerSetup: <class 'test_simple_such.A system:layer'>
+StopLayerSetup: <class 'test_simple_such.A system:layer'>
+StartLayerSetupTest: <class 'test_simple_such.A system:layer'>:test 0000: should do something \(test_simple_such.A system.test 0000: should do something\)
+StopLayerSetupTest: <class 'test_simple_such.A system:layer'>:test 0000: should do something \(test_simple_such.A system.test 0000: should do something\)
+StartLayerTeardownTest: <class 'test_simple_such.A system:layer'>:test 0000: should do something \(test_simple_such.A system.test 0000: should do something\)
+StopLayerTeardownTest: <class 'test_simple_such.A system:layer'>:test 0000: should do something \(test_simple_such.A system.test 0000: should do something\)
+StartLayerTeardown: <class 'test_simple_such.A system:layer'>
+StopLayerTeardown: <class 'test_simple_such.A system:layer'>\n*$"""  # noqa: E501
+        else:
+            expected = r"""^StartLayerSetup: <class 'test_simple_such.A system:layer'>
 StopLayerSetup: <class 'test_simple_such.A system:layer'>
 StartLayerSetupTest: <class 'test_simple_such.A system:layer'>:test 0000: should do something \(test_simple_such.A system\)
 StopLayerSetupTest: <class 'test_simple_such.A system:layer'>:test 0000: should do something \(test_simple_such.A system\)
@@ -42,7 +52,65 @@ StopLayerTeardown: <class 'test_simple_such.A system:layer'>\n*$"""  # noqa: E50
             "--plugin=layer_hooks_plugin",
             "test_such",
         )
-        expected = r"""StartLayerSetup: <class 'test_such.A system with complex setup:layer'>
+        if sys.version_info >= (3, 11):
+            expected = r"""StartLayerSetup: <class 'test_such.A system with complex setup:layer'>
+StopLayerSetup: <class 'test_such.A system with complex setup:layer'>
+StartLayerSetupTest: <class 'test_such.A system with complex setup:layer'>:test 0000: should do something \(test_such.A system with complex setup.test 0000: should do something\)
+StopLayerSetupTest: <class 'test_such.A system with complex setup:layer'>:test 0000: should do something \(test_such.A system with complex setup.test 0000: should do something\)
+StartLayerTeardownTest: <class 'test_such.A system with complex setup:layer'>:test 0000: should do something \(test_such.A system with complex setup.test 0000: should do something\)
+StopLayerTeardownTest: <class 'test_such.A system with complex setup:layer'>:test 0000: should do something \(test_such.A system with complex setup.test 0000: should do something\)
+StartLayerSetup: <class 'test_such.having an expensive fixture:layer'>
+StopLayerSetup: <class 'test_such.having an expensive fixture:layer'>
+StartLayerSetupTest: <class 'test_such.having an expensive fixture:layer'>:test 0000: should do more things \(test_such.having an expensive fixture.test 0000: should do more things\)
+StopLayerSetupTest: <class 'test_such.having an expensive fixture:layer'>:test 0000: should do more things \(test_such.having an expensive fixture.test 0000: should do more things\)
+StartLayerTeardownTest: <class 'test_such.having an expensive fixture:layer'>:test 0000: should do more things \(test_such.having an expensive fixture.test 0000: should do more things\)
+StopLayerTeardownTest: <class 'test_such.having an expensive fixture:layer'>:test 0000: should do more things \(test_such.having an expensive fixture.test 0000: should do more things\)
+StartLayerSetup: <class 'test_such.having another precondtion:layer'>
+StopLayerSetup: <class 'test_such.having another precondtion:layer'>
+StartLayerSetupTest: <class 'test_such.having another precondtion:layer'>:test 0000: should do that not this \(test_such.having another precondtion.test 0000: should do that not this\)
+StopLayerSetupTest: <class 'test_such.having another precondtion:layer'>:test 0000: should do that not this \(test_such.having another precondtion.test 0000: should do that not this\)
+StartLayerTeardownTest: <class 'test_such.having another precondtion:layer'>:test 0000: should do that not this \(test_such.having another precondtion.test 0000: should do that not this\)
+StopLayerTeardownTest: <class 'test_such.having another precondtion:layer'>:test 0000: should do that not this \(test_such.having another precondtion.test 0000: should do that not this\)
+StartLayerSetupTest: <class 'test_such.having another precondtion:layer'>:test 0001: should do this not that \(test_such.having another precondtion.test 0001: should do this not that\)
+StopLayerSetupTest: <class 'test_such.having another precondtion:layer'>:test 0001: should do this not that \(test_such.having another precondtion.test 0001: should do this not that\)
+StartLayerTeardownTest: <class 'test_such.having another precondtion:layer'>:test 0001: should do this not that \(test_such.having another precondtion.test 0001: should do this not that\)
+StopLayerTeardownTest: <class 'test_such.having another precondtion:layer'>:test 0001: should do this not that \(test_such.having another precondtion.test 0001: should do this not that\)
+StartLayerTeardown: <class 'test_such.having another precondtion:layer'>
+StopLayerTeardown: <class 'test_such.having another precondtion:layer'>
+StartLayerSetup: <class 'test_such.SomeLayer'>
+StopLayerSetup: <class 'test_such.SomeLayer'>
+StartLayerSetup: <class 'test_such.having a different precondition:layer'>
+StopLayerSetup: <class 'test_such.having a different precondition:layer'>
+StartLayerSetupTest: <class 'test_such.having a different precondition:layer'>:test 0000: should do something else \(test_such.having a different precondition.test 0000: should do something else\)
+StopLayerSetupTest: <class 'test_such.having a different precondition:layer'>:test 0000: should do something else \(test_such.having a different precondition.test 0000: should do something else\)
+StartLayerTeardownTest: <class 'test_such.having a different precondition:layer'>:test 0000: should do something else \(test_such.having a different precondition.test 0000: should do something else\)
+StopLayerTeardownTest: <class 'test_such.having a different precondition:layer'>:test 0000: should do something else \(test_such.having a different precondition.test 0000: should do something else\)
+StartLayerSetupTest: <class 'test_such.having a different precondition:layer'>:test 0001: should have another test \(test_such.having a different precondition.test 0001: should have another test\)
+StopLayerSetupTest: <class 'test_such.having a different precondition:layer'>:test 0001: should have another test \(test_such.having a different precondition.test 0001: should have another test\)
+StartLayerTeardownTest: <class 'test_such.having a different precondition:layer'>:test 0001: should have another test \(test_such.having a different precondition.test 0001: should have another test\)
+StopLayerTeardownTest: <class 'test_such.having a different precondition:layer'>:test 0001: should have another test \(test_such.having a different precondition.test 0001: should have another test\)
+StartLayerSetupTest: <class 'test_such.having a different precondition:layer'>:test 0002: should have access to an external fixture \(test_such.having a different precondition.test 0002: should have access to an external fixture\)
+StopLayerSetupTest: <class 'test_such.having a different precondition:layer'>:test 0002: should have access to an external fixture \(test_such.having a different precondition.test 0002: should have access to an external fixture\)
+StartLayerTeardownTest: <class 'test_such.having a different precondition:layer'>:test 0002: should have access to an external fixture \(test_such.having a different precondition.test 0002: should have access to an external fixture\)
+StopLayerTeardownTest: <class 'test_such.having a different precondition:layer'>:test 0002: should have access to an external fixture \(test_such.having a different precondition.test 0002: should have access to an external fixture\)
+StartLayerSetup: <class 'test_such.having a case inside the external fixture:layer'>
+StopLayerSetup: <class 'test_such.having a case inside the external fixture:layer'>
+StartLayerSetupTest: <class 'test_such.having a case inside the external fixture:layer'>:test 0000: should still have access to that fixture \(test_such.having a case inside the external fixture.test 0000: should still have access to that fixture\)
+StopLayerSetupTest: <class 'test_such.having a case inside the external fixture:layer'>:test 0000: should still have access to that fixture \(test_such.having a case inside the external fixture.test 0000: should still have access to that fixture\)
+StartLayerTeardownTest: <class 'test_such.having a case inside the external fixture:layer'>:test 0000: should still have access to that fixture \(test_such.having a case inside the external fixture.test 0000: should still have access to that fixture\)
+StopLayerTeardownTest: <class 'test_such.having a case inside the external fixture:layer'>:test 0000: should still have access to that fixture \(test_such.having a case inside the external fixture.test 0000: should still have access to that fixture\)
+StartLayerTeardown: <class 'test_such.having a case inside the external fixture:layer'>
+StopLayerTeardown: <class 'test_such.having a case inside the external fixture:layer'>
+StartLayerTeardown: <class 'test_such.having a different precondition:layer'>
+StopLayerTeardown: <class 'test_such.having a different precondition:layer'>
+StartLayerTeardown: <class 'test_such.SomeLayer'>
+StopLayerTeardown: <class 'test_such.SomeLayer'>
+StartLayerTeardown: <class 'test_such.having an expensive fixture:layer'>
+StopLayerTeardown: <class 'test_such.having an expensive fixture:layer'>
+StartLayerTeardown: <class 'test_such.A system with complex setup:layer'>
+StopLayerTeardown: <class 'test_such.A system with complex setup:layer'>\n*$"""  # noqa: E501
+        else:
+            expected = r"""StartLayerSetup: <class 'test_such.A system with complex setup:layer'>
 StopLayerSetup: <class 'test_such.A system with complex setup:layer'>
 StartLayerSetupTest: <class 'test_such.A system with complex setup:layer'>:test 0000: should do something \(test_such.A system with complex setup\)
 StopLayerSetupTest: <class 'test_such.A system with complex setup:layer'>:test 0000: should do something \(test_such.A system with complex setup\)
@@ -109,7 +177,21 @@ StopLayerTeardown: <class 'test_such.A system with complex setup:layer'>\n*$""" 
             "--plugin=layer_hooks_plugin",
             "test_layers_simple",
         )
-        expected = r"""^StartLayerSetup: <class 'test_layers_simple.Layer1'>
+        if sys.version_info >= (3, 11):
+            expected = r"""^StartLayerSetup: <class 'test_layers_simple.Layer1'>
+StopLayerSetup: <class 'test_layers_simple.Layer1'>
+StartLayerSetupTest: <class 'test_layers_simple.Layer1'>:test_1 \(test_layers_simple.TestSimple.test_1\)
+StopLayerSetupTest: <class 'test_layers_simple.Layer1'>:test_1 \(test_layers_simple.TestSimple.test_1\)
+StartLayerTeardownTest: <class 'test_layers_simple.Layer1'>:test_1 \(test_layers_simple.TestSimple.test_1\)
+StopLayerTeardownTest: <class 'test_layers_simple.Layer1'>:test_1 \(test_layers_simple.TestSimple.test_1\)
+StartLayerSetupTest: <class 'test_layers_simple.Layer1'>:test_2 \(test_layers_simple.TestSimple.test_2\)
+StopLayerSetupTest: <class 'test_layers_simple.Layer1'>:test_2 \(test_layers_simple.TestSimple.test_2\)
+StartLayerTeardownTest: <class 'test_layers_simple.Layer1'>:test_2 \(test_layers_simple.TestSimple.test_2\)
+StopLayerTeardownTest: <class 'test_layers_simple.Layer1'>:test_2 \(test_layers_simple.TestSimple.test_2\)
+StartLayerTeardown: <class 'test_layers_simple.Layer1'>
+StopLayerTeardown: <class 'test_layers_simple.Layer1'>\n*$"""  # noqa: E501
+        else:
+            expected = r"""^StartLayerSetup: <class 'test_layers_simple.Layer1'>
 StopLayerSetup: <class 'test_layers_simple.Layer1'>
 StartLayerSetupTest: <class 'test_layers_simple.Layer1'>:test_1 \(test_layers_simple.TestSimple\)
 StopLayerSetupTest: <class 'test_layers_simple.Layer1'>:test_1 \(test_layers_simple.TestSimple\)

--- a/nose2/tests/functional/test_layers_plugin.py
+++ b/nose2/tests/functional/test_layers_plugin.py
@@ -1,4 +1,4 @@
-from nose2.tests._common import FunctionalTestCase
+from nose2.tests._common import FunctionalTestCase, _method_name
 
 
 class TestLayers(FunctionalTestCase):
@@ -42,23 +42,39 @@ class TestLayers(FunctionalTestCase):
         proc = self.runIn(
             "scenario/layers", "-v", "--plugin=nose2.plugins.layers", "--layer-reporter"
         )
-        expect = r"""test \(test_layers.NoLayer\) ... ok
+        expect = (
+            r"""test \(test_layers.NoLayer"""
+            + _method_name()
+            + r"""\) ... ok
 Base
-  test \(test_layers.Outer\) ... ok
+  test \(test_layers.Outer"""
+            + _method_name()
+            + r"""\) ... ok
   LayerD
-    test \(test_layers.InnerD\) test with docstring ... ok
+    test \(test_layers.InnerD"""
+            + _method_name()
+            + r"""\) test with docstring ... ok
   LayerA
-    test \(test_layers.InnerA\) ... ok
+    test \(test_layers.InnerA"""
+            + _method_name()
+            + r"""\) ... ok
   LayerB
     LayerB_1
-      test \(test_layers.InnerB_1\) ... ok
+      test \(test_layers.InnerB_1"""
+            + _method_name()
+            + r"""\) ... ok
     LayerC
-      test \(test_layers.InnerC\) ... ok
-      test2 \(test_layers.InnerC\) ... ok
+      test \(test_layers.InnerC"""
+            + _method_name()
+            + r"""\) ... ok
+      test2 \(test_layers.InnerC"""
+            + _method_name("test2")
+            + r"""\) ... ok
     LayerA_1
-      test \(test_layers.InnerA_1\) ... ok""".split(
-            "\n"
-        )
+      test \(test_layers.InnerA_1"""
+            + _method_name()
+            + r"""\) ... ok"""
+        ).split("\n")
         self.assertTestRunOutputMatches(proc, stderr="Ran 8 tests")
         for line in expect:
             self.assertTestRunOutputMatches(proc, stderr=line)
@@ -71,10 +87,14 @@ Base
             "--layer-reporter",
         )
         expect = [
-            r"ERROR: fixture with a value test_err \(test_layers_with_errors.Test\)",
+            r"ERROR: fixture with a value test_err \(test_layers_with_errors.Test"
+            + _method_name("test_err")
+            + r"\)",
             "ERROR: A test scenario with errors should check for an attribute "
             "that does not exist and raise an error",
-            r"FAIL: fixture with a value test_fail \(test_layers_with_errors.Test\)",
+            r"FAIL: fixture with a value test_fail \(test_layers_with_errors.Test"
+            + _method_name("test_fail")
+            + r"\)",
             "FAIL: A test scenario with errors should check that value == 2 "
             "and fail",
         ]

--- a/nose2/tests/functional/test_mp_plugin.py
+++ b/nose2/tests/functional/test_mp_plugin.py
@@ -10,7 +10,7 @@ from nose2._vendor import six
 from nose2.plugins import buffer
 from nose2.plugins.loader import discovery, testcases
 from nose2.plugins.mp import MultiProcess, procserver
-from nose2.tests._common import Conn, FunctionalTestCase, support_file
+from nose2.tests._common import Conn, FunctionalTestCase, _method_name, support_file
 
 
 class TestMpPlugin(FunctionalTestCase):
@@ -403,10 +403,16 @@ class MPClassFixturesSupport(FunctionalTestCase):
         )
         # report should show correct names for all tests
         self.assertTestRunOutputMatches(
-            proc, stderr=r"test_1 \(test_cf_testcase.Test\) ... ok"
+            proc,
+            stderr=r"test_1 \(test_cf_testcase.Test"
+            + _method_name("test_1")
+            + r"\) ... ok",
         )
         self.assertTestRunOutputMatches(
-            proc, stderr=r"test_2 \(test_cf_testcase.Test\) ... ok"
+            proc,
+            stderr=r"test_2 \(test_cf_testcase.Test"
+            + _method_name("test_2")
+            + r"\) ... ok",
         )
         self.assertTestRunOutputMatches(proc, stderr="Ran 2 tests")
         self.assertEqual(proc.poll(), 0)
@@ -483,10 +489,16 @@ class MPModuleFixturesSupport(FunctionalTestCase):
         )
         # report should show correct names for all tests
         self.assertTestRunOutputMatches(
-            proc, stderr=r"test_1 \(test_mf_testcase.Test\) ... ok"
+            proc,
+            stderr=r"test_1 \(test_mf_testcase.Test"
+            + _method_name("test_1")
+            + r"\) ... ok",
         )
         self.assertTestRunOutputMatches(
-            proc, stderr=r"test_2 \(test_mf_testcase.Test\) ... ok"
+            proc,
+            stderr=r"test_2 \(test_mf_testcase.Test"
+            + _method_name("test_2")
+            + r"\) ... ok",
         )
         self.assertTestRunOutputMatches(proc, stderr="Ran 2 tests")
         self.assertEqual(proc.poll(), 0)

--- a/nose2/tests/functional/test_verbosity.py
+++ b/nose2/tests/functional/test_verbosity.py
@@ -1,4 +1,4 @@
-from nose2.tests._common import FunctionalTestCase, windows_ci_skip
+from nose2.tests._common import FunctionalTestCase, _method_name, windows_ci_skip
 
 _SUFFIX = """\
 ----------------------------------------------------------------------
@@ -6,7 +6,9 @@ Ran 1 test """
 
 Q_TEST_PATTERN = r"(?<!\.)(?<!ok)" + _SUFFIX
 MID_TEST_PATTERN = r"\." + "\n" + _SUFFIX
-V_TEST_PATTERN = r"test \(__main__\.Test\) \.\.\. ok" + "\n\n" + _SUFFIX
+V_TEST_PATTERN = (
+    r"test \(__main__\.Test" + _method_name() + r"\) \.\.\. ok" + "\n\n" + _SUFFIX
+)
 
 
 class TestVerbosity(FunctionalTestCase):


### PR DESCRIPTION
Tests are failing on Python 3.11 ([for example](https://github.com/nose-devs/nose2/runs/6151776462?check_suite_focus=true)) because there was a change to unittest in March to add the fully qualified name to the output:

* https://github.com/python/cpython/issues/58473
* https://github.com/python/cpython/pull/32138

This PR fixes the nose2 tests to include the method name for Python 3.11 (and newer).
