### PR TITLE
GitHub Actions: Temporarily allow Python 3.11-dev to fail

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,4 +55,8 @@ jobs:
       - name: install tox
         run: python -m pip install -U tox
       - name: test
+        if: ${{ matrix.python-version != '3.11-dev' }}
         run: python -m tox -e py
+      - name: test on Python 3.11-dev (allow failures)
+        if: ${{ matrix.python-version == '3.11-dev' }}
+        run: python -m tox -e py || true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,10 +12,10 @@ jobs:
     name: run tests from packaged source
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: 3.x
       - name: test
         run: |
           python setup.py sdist
@@ -35,7 +35,7 @@ jobs:
         # any additional builds for windows and macos
         # handled via `include` to avoid an over-large test matrix
         os: [ubuntu-latest]
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11-dev", "pypy-2.7", "pypy-3.7"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11-dev", "pypy-2.7", "pypy-3.8"]
         include:
           - os: windows-latest
             python-version: "2.7"
@@ -48,8 +48,8 @@ jobs:
     name: "python=${{ matrix.python-version }} os=${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: install tox


### PR DESCRIPTION
Tests on [Py311 beta 4](https://www.python.org/download/pre-releases) are currently broken so let's not block unrelated pull requests.

NOTE: This pull request does NOT fix test runs on `Python 3.11 beta 4`.  It merely allows them to fail until they are fixed.