### PR TITLE
Fix regex for Python 3.11 beta 4

### DIFF
--- a/nose2/tests/functional/test_prettyassert.py
+++ b/nose2/tests/functional/test_prettyassert.py
@@ -183,7 +183,6 @@ class TestPrettyAsserts(FunctionalTestCase):
         # look for typical unittest output
         expect_lines = [
             r"self.assertTrue\(x\)",
-            r"\s+\^+",
             "AssertionError: False is not true",
         ]
         if not DEBUG_RANGES:


### PR DESCRIPTION
Closes https://github.com/nose-devs/nose2/pull/526 as no longer needed.

Python 3.11 has started failing after beta has been released. See for example PR https://github.com/nose-devs/nose2/pull/527.

Fixes:

`    Regex didn't match: 'self.assertTrue\\(x\\)\n\\s+\\^+\nAssertionError: False is not true' not found in 'test_old_assertion (unittest_assertion.test_prettyassert_unittestassertion.TestFoo.test_old_assertion) ... FAIL\n\n======================================================================\nFAIL: test_old_assertion (unittest_assertion.test_prettyassert_unittestassertion.TestFoo.test_old_assertion)\n----------------------------------------------------------------------\nTraceback (most recent call last):\n  File "/private/tmp/nose2/nose2/tests/functional/support/scenario/pretty_asserts/unittest_assertion/test_prettyassert_unittestassertion.py", line 7, in test_old_assertion\n    self.assertTrue(x)\nAssertionError: False is not true\n\n----------------------------------------------------------------------\nRan 1 test in 0.000s\n\nFAILED (failures=1)\n'`

---

Adding formatting for clarity:

Regex didn't match: 

```
self.assertTrue\\(x\\)\n\\s+\\^+\nAssertionError: False is not true
```

not found in 

```
test_old_assertion (unittest_assertion.test_prettyassert_unittestassertion.TestFoo.test_old_assertion) ... FAIL

======================================================================
FAIL: test_old_assertion (unittest_assertion.test_prettyassert_unittestassertion.TestFoo.test_old_assertion)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/private/tmp/nose2/nose2/tests/functional/support/scenario/pretty_asserts/unittest_assertion/test_prettyassert_unittestassertion.py", line 7, in test_old_assertion
    self.assertTrue(x)
AssertionError: False is not true

----------------------------------------------------------------------
Ran 1 test in 0.000s\n\nFAILED (failures=1)

```

---

So it appears there's no longer an extra line between `self.assertTrue(x)` and `AssertionError: False is not true`

