### PR TITLE
Revert "Update tests to pass on py3.11"

### DIFF
--- a/nose2/tests/functional/test_prettyassert.py
+++ b/nose2/tests/functional/test_prettyassert.py
@@ -1,18 +1,4 @@
-import sys
-
 from nose2.tests._common import FunctionalTestCase, windows_ci_skip
-
-# detect if DEBUG_RANGES are enabled in the interpreter
-#
-# for now, assume it's on for py3.11+
-#
-# in 3.11 this is be part of the env var flag loading logic:
-# https://github.com/python/cpython/blob/99fcf1505218464c489d419d4500f126b6d6dc28/Python/initconfig.c#L1722-L1725
-#
-# if anyone runs into failures because they're setting PYTHONNODEBUGRANGES when running
-# tests, we may want to look into how to pull this value from `sys` or a similar module
-# note that this can be set via env var or a CLI flag
-DEBUG_RANGES = sys.version_info >= (3, 11)
 
 
 class TestPrettyAsserts(FunctionalTestCase):
@@ -181,14 +167,7 @@ class TestPrettyAsserts(FunctionalTestCase):
             "scenario/pretty_asserts/unittest_assertion", "-v", "--pretty-assert"
         )
         # look for typical unittest output
-        expect_lines = [
-            r"self.assertTrue\(x\)",
-            r"\s+\^+",
-            "AssertionError: False is not true",
-        ]
-        if not DEBUG_RANGES:
-            del expect_lines[1]
-        expected = "\n".join(expect_lines)
+        expected = "self.assertTrue\\(x\\)\nAssertionError: False is not true"
         stderr = self.assertProcOutputPattern(proc, expected)
         # the assertion line wasn't reprinted by prettyassert
         self.assertNotIn(">>> self.assertTrue", stderr)


### PR DESCRIPTION
This reverts commit b66885260907d7d5c1e8565fd0a13b392eb0d342 as suggested in https://github.com/nose-devs/nose2/pull/528#issuecomment-1185776389.

Replaces and closes https://github.com/nose-devs/nose2/pull/528.

Closes https://github.com/nose-devs/nose2/pull/526 as no longer needed.

