### PR TITLE
Provide clarity on `pip --upgrade` vs. `--user`, etc.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: install tox
-        run: python -m pip install -U tox
+        run: python -m pip install --upgrade tox
       - name: test
         run: python -m tox -e py


### PR DESCRIPTION
`pip install` has [command line options](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-user) for:
* --upgrade
* --upgrade-strategy
* --user
* --use-pep517

In a workflow, it is better to be explicit about which of the four we are using.