### PR TITLE
docs: Fix a few typos

### DIFF
--- a/nose2/plugins/mp.py
+++ b/nose2/plugins/mp.py
@@ -294,7 +294,7 @@ class MultiProcess(events.Plugin):
         """
         Generate the session information passed to work process.
 
-        CAVEAT: The entire contents of which *MUST* be pickeable
+        CAVEAT: The entire contents of which *MUST* be pickleable
         and safe to use in the subprocess.
 
         This probably includes:

--- a/nose2/tests/functional/test_mp_plugin.py
+++ b/nose2/tests/functional/test_mp_plugin.py
@@ -266,7 +266,7 @@ class MPPluginTestRuns(FunctionalTestCase):
 
         def save_return():
             """
-            Popen.communciate() blocks.  Use a thread-safe queue
+            Popen.communicate() blocks.  Use a thread-safe queue
             to return any exceptions.  Ideally, this completes
             and returns None.
             """


### PR DESCRIPTION
There are small typos in:
- nose2/plugins/mp.py
- nose2/tests/functional/test_mp_plugin.py

Fixes:
- Should read `pickleable` rather than `pickeable`.
- Should read `communicate` rather than `communciate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md