### PR TITLE
Separate py3.6 CI testing to use older ubuntu

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,8 +35,11 @@ jobs:
         # any additional builds for windows and macos
         # handled via `include` to avoid an over-large test matrix
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.9"]
         include:
+          # split off py3.6 from 'ubuntu-latest' because 3.6 isn't compatible with openssl v3
+          - os: ubuntu-20.04
+            python-version: "3.6"
           - os: windows-latest
             python-version: "3.x"
           - os: macos-latest


### PR DESCRIPTION
'py3.6 x ubuntu-22.04' isn't a valid combination because py3.6 can't compile on the OpenSSL version (3.x) provided on 22.04 . As is reasonable and their prerogative, GitHub is not offering this combination from their built pythons.

To fix / workaround the issue, just move to `ubuntu-20.04` for the 3.6 test run.