### PR TITLE
Add addDuration() for Python >= 3.12

### DIFF
--- a/nose2/result.py
+++ b/nose2/result.py
@@ -50,6 +50,9 @@ class PluggableTestResult:
         event = events.StopTestEvent(test, self, time.time())
         self.session.hooks.stopTest(event)
 
+    def addDuration(self, test, elapsed):  # For Python >= 3.12
+        pass
+
     def addError(self, test, err):
         """Test case resulted in error.
 


### PR DESCRIPTION
A subset of #568
Fixes: #569

See the Python 3.12 changes discussed at https://github.com/nose-devs/nose2/issues/569#issuecomment-1515828179