### PR TITLE
Remove support for python3.6

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,9 +45,6 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.9"]
         include:
-          # split off py3.6 from 'ubuntu-latest' because 3.6 isn't compatible with openssl v3
-          - os: ubuntu-20.04
-            python-version: "3.6"
           - os: windows-latest
             python-version: "3.x"
           - os: macos-latest

--- a/.github/workflows/test-on-downstream-projects.yaml
+++ b/.github/workflows/test-on-downstream-projects.yaml
@@ -45,7 +45,7 @@ jobs:
       # https://gitlab.com/mailman/mailman/-/blob/master/tox.ini
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - run: python -m pip install tox
       - name: setup testenv
         run: tox -e py-nocov --devenv testenv

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,11 @@ functionality or contain necessary breaking changes. Minor releases are
 primarily used for bugfix or small features which are unlikely to break users'
 testsuites.
 
+0.13.1 (Unreleased)
+-------------------
+
+* Remove support for `python3.6`
+
 0.13.0 (2023-04-29)
 -------------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{36,37,38,39,310,311}{,-nocov},pypy,docs,lint
+envlist=py{37,38,39,310,311}{,-nocov},pypy,docs,lint
 
 [testenv]
 passenv = CI


### PR DESCRIPTION
It was already EOL at the time of the 0.13.0 release, but was retained as a courtesy towards users who might still be testing against it.