### PR TITLE
Update config to drop py3.7 and add 3.12

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
         # any additional builds for windows and macos
         # handled via `include` to avoid an over-large test matrix
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9"]
         include:
           - os: windows-latest
             python-version: "3.x"
@@ -56,6 +56,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: install tox
         run: python -m pip install -U tox
       - name: test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,13 +6,6 @@ on:
   schedule:
     - cron: '0 4 * * 1'
 jobs:
-  ruff:  # https://beta.ruff.rs
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - run: pip install --user ruff
-    - run: ruff --format=github .
-
   # this job ensures that tests can run from the packaged version, which means
   # that nose2 is correctly packaging and distributing its tests
   test-sdist:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
   hooks:
     - id: validate-pyproject
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: 0.11.2
+  rev: 1.1.0
   hooks:
     - id: pyproject-fmt
+      additional_dependencies: ["tox>=4.9"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers=[
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Libraries",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ ignore = [
   "RUF005",
   "RUF100"
 ]
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.isort]
 known-third-party = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ license = {text = "BSD-2-Clause"}
 authors = [
   { name = "Stephen Rosen", email = "dev@nose2.io" },
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 classifiers=[
   "Development Status :: 4 - Beta",
   "Environment :: Console",
@@ -26,12 +26,11 @@ classifiers=[
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Libraries",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers=[
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Libraries",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{37,38,39,310,311}{,-nocov},pypy,docs,lint
+envlist=py{38,39,310,311,312}{,-nocov},pypy,docs,lint
 
 [testenv]
 passenv = CI


### PR DESCRIPTION
Update configs to add 3.12.0rc1 to build matrix.

Also update requires-python data.

---

The 3.12 builds have been broken on some of the alphas; a local test on 3.12.0rc1 worked for me, so try it out in GitHub.