### PR TITLE
remove remaining six crumbs

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -36,4 +36,3 @@ see :doc:`usage` and :doc:`configuration`.
 
 .. _pip : http://pypi.python.org/pypi/pip/1.0.2
 .. _pypi : http://pypi.python.org/pypi
-.. _six : http://pypi.python.org/pypi/six/1.1.0

--- a/nose2/plugins/layers.py
+++ b/nose2/plugins/layers.py
@@ -255,10 +255,10 @@ class LayerReporter(events.Plugin):
 # for debugging
 # def printtree(suite, indent=''):
 #     import unittest
-#     six.print_('%s%s ->' % (indent, getattr(suite, 'layer', 'no layer')))
+#     print('%s%s ->' % (indent, getattr(suite, 'layer', 'no layer')))
 #     for test in suite:
 #         if isinstance(test, unittest.BaseTestSuite):
 #             printtree(test, indent + '  ')
 #         else:
-#             six.print_('%s %s' % (indent, test))
-#     six.print_('%s<- %s' % (indent, getattr(suite, 'layer', 'no layer')))
+#             print('%s %s' % (indent, test))
+#     print('%s<- %s' % (indent, getattr(suite, 'layer', 'no layer')))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,6 @@ target-version = "py37"
 known-third-party = [
   "coverage",
   "mock",
-  "six",
 ]
 
 [tool.ruff.mccabe]


### PR DESCRIPTION
Hi,

`isort` don't need `six` anymore

https://wiki.debian.org/Python3-six-removal