### PR TITLE
Fixes for python3.12+

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,10 +15,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.12"
+      - name: install build prereqs
+        run: pip install build
       - name: test
         run: |
-          python setup.py sdist
+          python -m build --sdist
           version="$(cat nose2/__init__.py | grep '^__version__' |  cut -d '"' -f2)"
           cd dist
           tar -xzf "nose2-${version}.tar.gz"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,12 @@ testsuites.
 Unreleased
 ----------
 
+* Fix the reporting of skipped tests in verbose mode on newer pythons (3.12.1+),
+  in which a skipped test is no longer treated as "started".
+
+  ``nose2`` will not introduce a ``StartTestEvent`` in such cases --
+  the fix is narrowly and adjustment to the test reporter.
+
 0.14.0 (2023-10-04)
 -------------------
 

--- a/nose2/plugins/result.py
+++ b/nose2/plugins/result.py
@@ -80,6 +80,9 @@ class ResultReporter(events.Plugin):
           etc)
 
         """
+        if not event.result.test_started:
+            self._show_test_description(self.stream, event.test)
+
         if event.outcome == result.ERROR:
             self.reportCategories["errors"].append(event)
             self._reportError(event)
@@ -145,11 +148,14 @@ class ResultReporter(events.Plugin):
         self.session.hooks.reportStartTest(evt)
         if evt.handled:
             return
+        self._show_test_description(evt.stream, event.test)
+
+    def _show_test_description(self, stream, test):
         if self.session.verbosity > 1:
             # allow other plugins to override/spy on stream
-            evt.stream.write(self._getDescription(event.test, errorList=False))
-            evt.stream.write(" ... ")
-            evt.stream.flush()
+            stream.write(self._getDescription(test, errorList=False))
+            stream.write(" ... ")
+            stream.flush()
 
     def _reportError(self, event):
         self._report(event, "reportError", "E", "ERROR")

--- a/nose2/result.py
+++ b/nose2/result.py
@@ -31,6 +31,9 @@ class PluggableTestResult:
         self.shouldStop = False
         # XXX TestCase.subTest expects a result.failfast attribute
         self.failfast = False
+        # track whether or not the test actually started
+        # (in py3.12.1+ a skipped test is not started)
+        self.test_started = False
 
     def startTest(self, test):
         """Start a test case.
@@ -40,6 +43,7 @@ class PluggableTestResult:
         """
         event = events.StartTestEvent(test, self, time.time())
         self.session.hooks.startTest(event)
+        self.test_started = True
 
     def stopTest(self, test):
         """Stop a test case.

--- a/nose2/tests/functional/test_junitxml_plugin.py
+++ b/nose2/tests/functional/test_junitxml_plugin.py
@@ -161,7 +161,7 @@ class JunitXmlPluginFunctionalTest(FunctionalTestCase, TestCase):
 
         self.assertTestRunOutputMatches(
             proc,
-            stderr=r"test \(test_junitxml_skip_reason.Test"
+            stderr=r"test \(test_junitxml_skip_reason\.Test"
             + _method_name()
             + r"\) \.* skip",
         )


### PR DESCRIPTION
There are two basic fixes here.

1. A fix to `nose2` behavior for 3.12.1+ (documented in the changelog)
2. A fix to CI config to handle the absence of setuptools on python3.12 workers