### PR TITLE
Adjust the regex in test_unittest_assertion for Python 3.13

### DIFF
--- a/nose2/tests/functional/test_prettyassert.py
+++ b/nose2/tests/functional/test_prettyassert.py
@@ -167,7 +167,7 @@ class TestPrettyAsserts(FunctionalTestCase):
             "scenario/pretty_asserts/unittest_assertion", "-v", "--pretty-assert"
         )
         # look for typical unittest output
-        expected = "self.assertTrue\\(x\\)\nAssertionError: False is not true"
+        expected = "self.assertTrue\\(x\\)\n(\W+\n)?AssertionError: False is not true"
         stderr = self.assertProcOutputPattern(proc, expected)
         # the assertion line wasn't reprinted by prettyassert
         self.assertNotIn(">>> self.assertTrue", stderr)


### PR DESCRIPTION
Before this PR, one test fails on Python 3.13 (3.13.0a6):

```
======================================================================
FAIL: test_unittest_assertion (nose2.tests.functional.test_prettyassert.TestPrettyAsserts.test_unittest_assertion)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ben/src/forks/nose2/nose2/tests/functional/test_prettyassert.py", line 171, in test_unittest_assertion
    stderr = self.assertProcOutputPattern(proc, expected)
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/home/ben/src/forks/nose2/nose2/tests/functional/test_prettyassert.py", line 15, in assertProcOutputPattern
    self.assertTestRunOutputMatches(proc, stderr=expected)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ben/src/forks/nose2/nose2/tests/_common.py", line 82, in assertTestRunOutputMatches
    self.assertRegex(util.safe_decode(cmd_stderr), stderr)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Regex didn't match: 'self.assertTrue\\(x\\)\nAssertionError: False is not true' not found in 'test_old_assertion (unittest_assertion.test_prettyassert_unittestassertion.TestFoo.test_old_assertion) ... FAIL\n\n======================================================================\nFAIL: test_old_assertion (unittest_assertion.test_prettyassert_unittestassertion.TestFoo.test_old_assertion)\n----------------------------------------------------------------------\nTraceback (most recent call last):\n  File "/home/ben/src/forks/nose2/nose2/tests/functional/support/scenario/pretty_asserts/unittest_assertion/test_prettyassert_unittestassertion.py", line 7, in test_old_assertion\n    self.assertTrue(x)\n    ~~~~~~~~~~~~~~~^^^\nAssertionError: False is not true\n\n----------------------------------------------------------------------\nRan 1 test in 0.000s\n\nFAILED (failures=1)\n'
```

Close inspection shows that Python 3.13 has inserted the line `    ~~~~~~~~~~~~~~~^^^` between `    self.assertTrue(x)` and `AssertionError: False is not true` to indicate the error location as part of https://docs.python.org/3.13/whatsnew/3.13.html#improved-error-messages.

This PR adds `(\W+\n)?` in the regex to accept one optional line composed entirely of non-word (non-alphanumeric) characters in the expected output.

After this PR, all tests pass with `tox -e python313-nocov`.