### PR TITLE
Make mypy pass and add it to CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,17 @@ jobs:
           pip install -e '.[dev]'
           nose2 -v --pretty-assert
 
+  typing:
+    name: 'typing (mypy)'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install tox
+      - run: tox run -e mypy
+
   test:
     strategy:
       fail-fast: false

--- a/nose2/_toml.py
+++ b/nose2/_toml.py
@@ -1,4 +1,9 @@
+from __future__ import annotations
+
+import types
+
 TOML_ENABLED: bool = False
+toml: types.ModuleType | None = None
 
 try:
     import tomllib as toml
@@ -15,7 +20,7 @@ except ImportError:
 
 
 def load_toml(file: str) -> dict:
-    if not TOML_ENABLED:
+    if toml is None:
         raise RuntimeError("toml library not found. Please install 'tomli'.")
     with open(file, "rb") as fp:
         return toml.load(fp)

--- a/nose2/events.py
+++ b/nose2/events.py
@@ -3,6 +3,7 @@
 # code developed in reference to that module and others within unittest2.
 # unittest2 is Copyright (c) 2001-2010 Python Software Foundation; All
 # Rights Reserved. See: http://docs.python.org/license.html
+from __future__ import annotations
 
 import argparse
 import logging
@@ -315,7 +316,7 @@ class PluginInterface:
         "handleDir",
         # ... etc?
     )
-    hookClass = Hook
+    hookClass: type[Hook] = Hook
 
     def __init__(self):
         self.hooks = {}

--- a/nose2/events.py
+++ b/nose2/events.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import typing as t
 import unittest
 
 from nose2 import config, util
@@ -363,7 +364,7 @@ class Event:
 
     """
 
-    _attrs = ("handled",)
+    _attrs: t.ClassVar[tuple[str, ...]] = ("handled",)
     version = "0.4"
 
     def __init__(self, **metadata):

--- a/nose2/plugins/loader/eggdiscovery.py
+++ b/nose2/plugins/loader/eggdiscovery.py
@@ -13,8 +13,11 @@ are examined for tests.
 
 """
 
+from __future__ import annotations
+
 import logging
 import os
+import types
 
 from nose2 import events
 from nose2.plugins.loader import discovery
@@ -23,7 +26,9 @@ __unittest = True
 log = logging.getLogger(__name__)
 
 try:
-    import pkg_resources
+    import pkg_resources as _pkg_resources_mod
+
+    pkg_resources: types.ModuleType | None = _pkg_resources_mod
 except ImportError:
     pkg_resources = None
 

--- a/nose2/plugins/loader/eggdiscovery.py
+++ b/nose2/plugins/loader/eggdiscovery.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import logging
 import os
-import types
 
 from nose2 import events
 from nose2.plugins.loader import discovery
@@ -26,11 +25,11 @@ __unittest = True
 log = logging.getLogger(__name__)
 
 try:
-    import pkg_resources as _pkg_resources_mod
+    import pkg_resources
 
-    pkg_resources: types.ModuleType | None = _pkg_resources_mod
+    _has_pkg_resources = True
 except ImportError:
-    pkg_resources = None
+    _has_pkg_resources = False
 
 
 class EggDiscoveryLoader(events.Plugin, discovery.Discoverer):
@@ -85,7 +84,7 @@ class EggDiscoveryLoader(events.Plugin, discovery.Discoverer):
     def _find_tests_in_dir(self, event, full_path, top_level):
         if os.path.exists(full_path):
             return
-        elif pkg_resources and full_path.find(".egg") != -1:
+        elif _has_pkg_resources and full_path.find(".egg") != -1:
             egg_path = full_path.split(".egg")[0] + ".egg"
             for dist in pkg_resources.find_distributions(egg_path):
                 for modname in dist._get_metadata("top_level.txt"):

--- a/nose2/plugins/printhooks.py
+++ b/nose2/plugins/printhooks.py
@@ -12,11 +12,13 @@ instances of a :class:`~nose2.events.Hook` subclass that prints information abou
 each call.
 """
 
+from __future__ import annotations
+
 import sys
 
 from nose2 import events
 
-INDENT = []
+INDENT: list[str] = []
 __unittest = True
 
 

--- a/nose2/tests/_common.py
+++ b/nose2/tests/_common.py
@@ -210,13 +210,13 @@ class NotReallyAProc:
         self.cwd = os.getcwd()
         if self.chdir:
             os.chdir(self.chdir)
-        self.stdout = sys.stdout = sys.__stdout__ = io.StringIO()
-        self.stderr = sys.stderr = sys.__stderr__ = io.StringIO()
+        self.stdout = sys.stdout = sys.__stdout__ = io.StringIO()  # type: ignore[misc]
+        self.stderr = sys.stderr = sys.__stderr__ = io.StringIO()  # type: ignore[misc]
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        sys.stdout = sys.__stdout__ = self._stdout
-        sys.stderr = sys.__stderr__ = self._stderr
+        sys.stdout = sys.__stdout__ = self._stdout  # type: ignore[misc]
+        sys.stderr = sys.__stderr__ = self._stderr  # type: ignore[misc]
         if self.chdir:
             os.chdir(self.cwd)
         return False

--- a/nose2/tests/functional/support/scenario/module_fixtures/test_mf_param_func.py
+++ b/nose2/tests/functional/support/scenario/module_fixtures/test_mf_param_func.py
@@ -14,4 +14,4 @@ def test(p):
     assert THINGS, "setup didn't run I think"
 
 
-test.paramList = (1,)
+test.paramList = (1,)  # type: ignore[attr-defined]

--- a/nose2/tests/functional/support/scenario/test_classes/test_classes.py
+++ b/nose2/tests/functional/support/scenario/test_classes/test_classes.py
@@ -12,4 +12,4 @@ class Test:
     def test_params(self, a):
         pass
 
-    test_params.paramList = (1, 2)
+    test_params.paramList = (1, 2)  # type: ignore[attr-defined]

--- a/nose2/tests/functional/support/scenario/test_classes/test_fixtures.py
+++ b/nose2/tests/functional/support/scenario/test_classes/test_fixtures.py
@@ -29,4 +29,4 @@ class Test:
         assert self.test_setup
         assert self.setup
 
-    test_params.paramList = (1, 2)
+    test_params.paramList = (1, 2)  # type: ignore[attr-defined]

--- a/nose2/tests/functional/support/scenario/test_classes_mp/test_classes_mp.py
+++ b/nose2/tests/functional/support/scenario/test_classes_mp/test_classes_mp.py
@@ -12,4 +12,4 @@ class Test:
     def test_params(self, a):
         pass
 
-    test_params.paramList = (1, 2)
+    test_params.paramList = (1, 2)  # type: ignore[attr-defined]

--- a/nose2/tests/functional/support/scenario/test_classes_mp/test_fixtures_mp.py
+++ b/nose2/tests/functional/support/scenario/test_classes_mp/test_fixtures_mp.py
@@ -29,4 +29,4 @@ class Test:
         assert self.test_setup
         assert self.setup
 
-    test_params.paramList = (1, 2)
+    test_params.paramList = (1, 2)  # type: ignore[attr-defined]

--- a/nose2/tests/functional/support/scenario/tests_in_package/pkg1/test/test_things.py
+++ b/nose2/tests/functional/support/scenario/tests_in_package/pkg1/test/test_things.py
@@ -7,65 +7,65 @@ class SomeTests(unittest.TestCase):
     def test_ok(self):
         pass
 
-    test_ok.tags = ["method", "pass"]
-    test_ok.a = 0
-    test_ok.b = 1
+    test_ok.tags = ["method", "pass"]  # type: ignore[attr-defined]
+    test_ok.a = 0  # type: ignore[attr-defined]
+    test_ok.b = 1  # type: ignore[attr-defined]
 
     def test_typeerr(self):
         raise TypeError("oops")
 
-    test_typeerr.tags = ["method"]
+    test_typeerr.tags = ["method"]  # type: ignore[attr-defined]
 
     def test_failed(self):
         print("Hello stdout")
         assert False, "I failed"
 
-    test_failed.tags = ["method"]
+    test_failed.tags = ["method"]  # type: ignore[attr-defined]
 
     def test_skippy(self):
         raise unittest.SkipTest("I wanted to skip")
 
-    test_skippy.a = 1
-    test_skippy.b = 1
+    test_skippy.a = 1  # type: ignore[attr-defined]
+    test_skippy.b = 1  # type: ignore[attr-defined]
 
     def test_gen_method(self):
         def check(x):
             assert x == 1
 
-        check.b = 2
+        check.b = 2  # type: ignore[attr-defined]
         yield check, 1
         yield check, 2
 
-    test_gen_method.a = 1
-    test_gen_method.b = 1
+    test_gen_method.a = 1  # type: ignore[attr-defined]
+    test_gen_method.b = 1  # type: ignore[attr-defined]
 
     def test_params_method(self, a):
         self.assertEqual(a, 1)
 
-    test_params_method.paramList = (1, 2)
-    test_params_method.a = 1
+    test_params_method.paramList = (1, 2)  # type: ignore[attr-defined]
+    test_params_method.a = 1  # type: ignore[attr-defined]
 
 
 def test_func():
     assert 1 == 1
 
 
-test_func.a = 1
-test_func.b = 0
-test_func.tags = ["func", "pass"]
+test_func.a = 1  # type: ignore[attr-defined]
+test_func.b = 0  # type: ignore[attr-defined]
+test_func.tags = ["func", "pass"]  # type: ignore[attr-defined]
 
 
 def test_gen():
     def check(a, b):
         assert a == b
 
-    check.tags = ["func"]
+    check.tags = ["func"]  # type: ignore[attr-defined]
     for i in range(0, 5):
         yield check, (i, i)
 
 
-test_gen.testGenerator = True
-test_gen.tags = ["func"]
+test_gen.testGenerator = True  # type: ignore[attr-defined]
+test_gen.tags = ["func"]  # type: ignore[attr-defined]
 
 
 def test_gen_nose_style():
@@ -88,19 +88,19 @@ def test_fixt():
     assert did_setup
 
 
-test_fixt.setup = setup
+test_fixt.setup = setup  # type: ignore[attr-defined]
 
 
 def test_params_func(a):
     assert a == 1
 
 
-test_params_func.paramList = (1, 2)
-test_params_func.tags = ["func"]
+test_params_func.paramList = (1, 2)  # type: ignore[attr-defined]
+test_params_func.tags = ["func"]  # type: ignore[attr-defined]
 
 
 def test_params_func_multi_arg(a, b):
     assert a == b
 
 
-test_params_func_multi_arg.paramList = ((1, 1), (1, 2), (2, 2))
+test_params_func_multi_arg.paramList = ((1, 1), (1, 2), (2, 2))  # type: ignore[attr-defined]  # noqa: E501

--- a/nose2/tests/functional/support/scenario/tests_in_unzipped_eggs/pkgunegg-0.0.0-py2.7.egg/pkgunegg/test/test_things.py
+++ b/nose2/tests/functional/support/scenario/tests_in_unzipped_eggs/pkgunegg-0.0.0-py2.7.egg/pkgunegg/test/test_things.py
@@ -7,65 +7,65 @@ class SomeTests(unittest.TestCase):
     def test_ok(self):
         pass
 
-    test_ok.tags = ["method", "pass"]
-    test_ok.a = 0
-    test_ok.b = 1
+    test_ok.tags = ["method", "pass"]  # type: ignore[attr-defined]
+    test_ok.a = 0  # type: ignore[attr-defined]
+    test_ok.b = 1  # type: ignore[attr-defined]
 
     def test_typeerr(self):
         raise TypeError("oops")
 
-    test_typeerr.tags = ["method"]
+    test_typeerr.tags = ["method"]  # type: ignore[attr-defined]
 
     def test_failed(self):
         print("Hello stdout")
         assert False, "I failed"
 
-    test_failed.tags = ["method"]
+    test_failed.tags = ["method"]  # type: ignore[attr-defined]
 
     def test_skippy(self):
         raise unittest.SkipTest("I wanted to skip")
 
-    test_skippy.a = 1
-    test_skippy.b = 1
+    test_skippy.a = 1  # type: ignore[attr-defined]
+    test_skippy.b = 1  # type: ignore[attr-defined]
 
     def test_gen_method(self):
         def check(x):
             assert x == 1
 
-        check.b = 2
+        check.b = 2  # type: ignore[attr-defined]
         yield check, 1
         yield check, 2
 
-    test_gen_method.a = 1
-    test_gen_method.b = 1
+    test_gen_method.a = 1  # type: ignore[attr-defined]
+    test_gen_method.b = 1  # type: ignore[attr-defined]
 
     def test_params_method(self, a):
         self.assertEqual(a, 1)
 
-    test_params_method.paramList = (1, 2)
-    test_params_method.a = 1
+    test_params_method.paramList = (1, 2)  # type: ignore[attr-defined]
+    test_params_method.a = 1  # type: ignore[attr-defined]
 
 
 def test_func():
     assert 1 == 1
 
 
-test_func.a = 1
-test_func.b = 0
-test_func.tags = ["func", "pass"]
+test_func.a = 1  # type: ignore[attr-defined]
+test_func.b = 0  # type: ignore[attr-defined]
+test_func.tags = ["func", "pass"]  # type: ignore[attr-defined]
 
 
 def test_gen():
     def check(a, b):
         assert a == b
 
-    check.tags = ["func"]
+    check.tags = ["func"]  # type: ignore[attr-defined]
     for i in range(0, 5):
         yield check, (i, i)
 
 
-test_gen.testGenerator = True
-test_gen.tags = ["func"]
+test_gen.testGenerator = True  # type: ignore[attr-defined]
+test_gen.tags = ["func"]  # type: ignore[attr-defined]
 
 
 def test_gen_nose_style():
@@ -88,19 +88,19 @@ def test_fixt():
     assert did_setup
 
 
-test_fixt.setup = setup
+test_fixt.setup = setup  # type: ignore[attr-defined]
 
 
 def test_params_func(a):
     assert a == 1
 
 
-test_params_func.paramList = (1, 2)
-test_params_func.tags = ["func"]
+test_params_func.paramList = (1, 2)  # type: ignore[attr-defined]
+test_params_func.tags = ["func"]  # type: ignore[attr-defined]
 
 
 def test_params_func_multi_arg(a, b):
     assert a == b
 
 
-test_params_func_multi_arg.paramList = ((1, 1), (1, 2), (2, 2))
+test_params_func_multi_arg.paramList = ((1, 1), (1, 2), (2, 2))  # type: ignore[attr-defined]  # noqa: E501

--- a/nose2/tests/functional/support/such/test_such.py
+++ b/nose2/tests/functional/support/such/test_such.py
@@ -51,7 +51,7 @@ with such.A("system with complex setup") as it:
     #
     with it.having("an expensive fixture"):
 
-        @it.has_setup  # noqa: F811
+        @it.has_setup
         def setup():  # noqa: F811
             it.things.append(2)
 
@@ -61,7 +61,7 @@ with such.A("system with complex setup") as it:
         # them. Tests can call any and all TestCase methods on this
         # instance.
         #
-        @it.should("do more things")  # noqa: F811
+        @it.should("do more things")
         def test(case):  # noqa: F811
             case.assertEqual(it.things[-1], 2)
 
@@ -70,15 +70,15 @@ with such.A("system with complex setup") as it:
         #
         with it.having("another precondition"):
 
-            @it.has_setup  # noqa: F811
+            @it.has_setup
             def setup():  # noqa: F811
                 it.things.append(3)
 
-            @it.has_teardown  # noqa: F811
+            @it.has_teardown
             def teardown():  # noqa: F811
                 it.things.pop()
 
-            @it.should("do that not this")  # noqa: F811
+            @it.should("do that not this")  # type: ignore[no-redef]
             def test(case):  # noqa: F811
                 it.things.append(4)
                 #
@@ -87,7 +87,7 @@ with such.A("system with complex setup") as it:
                 case.addCleanup(it.things.pop)
                 case.assertEqual(it.things[-1], 4, it.things)
 
-            @it.should("do this not that")  # noqa: F811
+            @it.should("do this not that")  # type: ignore[no-redef]
             def test(case):  # noqa: F811
                 case.assertEqual(it.things[-1], 3, it.things[:])
 
@@ -104,11 +104,11 @@ with such.A("system with complex setup") as it:
             #
             it.uses(SomeLayer)
 
-            @it.has_setup  # noqa: F811
+            @it.has_setup
             def setup():  # noqa: F811
                 it.things.append(99)
 
-            @it.has_teardown  # noqa: F811
+            @it.has_teardown
             def teardown():  # noqa: F811
                 it.things.pop()
 
@@ -127,24 +127,24 @@ with such.A("system with complex setup") as it:
                 delattr(it, "is_funny")
                 delattr(case, "is_funny")
 
-            @it.should("do something else")  # noqa: F811
+            @it.should("do something else")  # type: ignore[no-redef]
             def test(case):  # noqa: F811
                 assert it.things[-1] == 99
                 assert it.is_funny
                 assert case.is_funny
 
-            @it.should("have another test")  # noqa: F811
+            @it.should("have another test")  # type: ignore[no-redef]
             def test(case):  # noqa: F811
                 assert it.is_funny
                 assert case.is_funny
 
-            @it.should("have access to an external fixture")  # noqa: F811
+            @it.should("have access to an external fixture")  # type: ignore[no-redef]
             def test(case):  # noqa: F811
                 assert it.somelayer
 
             with it.having("a case inside the external fixture"):
 
-                @it.should("still have access to that fixture")  # noqa: F811
+                @it.should("still have access to that fixture")  # type: ignore[no-redef]  # noqa: E501
                 def test(case):  # noqa: F811
                     assert it.somelayer
 

--- a/nose2/tests/functional/test_eggdiscovery_loader.py
+++ b/nose2/tests/functional/test_eggdiscovery_loader.py
@@ -6,11 +6,9 @@ import nose2.plugins.loader.eggdiscovery  # noqa: F401
 from nose2.tests._common import FunctionalTestCase, support_file
 
 try:
-    import pkg_resources
-
+    import pkg_resources  # noqa: F401
 except ImportError:
-    pkg_resources = None
-
+    pass
 else:
 
     class EggDiscoveryFunctionalTest(FunctionalTestCase):

--- a/nose2/tests/unit/test_prof_plugin.py
+++ b/nose2/tests/unit/test_prof_plugin.py
@@ -22,7 +22,11 @@ class TestProfPlugin(TestCase):
     def test_startTestRun_sets_executeTests(self):
         _prof = Stub()
         _prof.runcall = object()
-        prof.cProfile.Profile = lambda: _prof
+
+        def _profile_call() -> Stub:
+            return _prof
+
+        prof.cProfile.Profile = _profile_call
         event = StartTestRunEvent(
             runner=None, suite=None, result=None, startTime=None, executeTests=None
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,12 @@ known_third_party = [
   "coverage",
   "mock",
 ]
+
+[tool.mypy]
+# strict = true
+sqlite_cache = true
+ignore_missing_imports = true
+disallow_subclassing_any = false
+files = [
+  "nose2",
+]

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands = pre-commit run --all-files
 [testenv:mypy]
 extras = dev
 deps =
-    mypy
+    mypy==1.10.0
     types-setuptools
     types-docutils
     tomli

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,8 @@ deps =
     mypy
     types-setuptools
     types-docutils
+    tomli
+    coverage
 commands =
     mypy nose2/ {posargs}
 


### PR DESCRIPTION
In short, get type checking to pass and start enforcing it.

- Refine mypy config
- Add type-ignores for testsuite stdio manipulations
- Add type-ignores to 'test_such.py'
- Handle type errors in nose/plugins/
- Fix type annotations for tomllib/tomli
- Set the type of Event._attrs
- Refine typing of conditional imports
- Add type-ignore comments to functional tests
- Add mypy run to CI
