### PR TITLE
Fix a bug with ini configs lacking '.cfg' suffix

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,13 @@ testsuites.
 Unreleased
 ----------
 
+Fixed
+~~~~~
+
+* Fix a bug with config loading which caused custom ini configs not to load if
+  they were not named with a ``.cfg`` extension. Thanks :user:`grhwalls` for
+  the bug report!
+
 0.15.0 (2024-05-30)
 -------------------
 

--- a/nose2/session.py
+++ b/nose2/session.py
@@ -1,8 +1,7 @@
 import argparse
 import logging
 import os
-
-# py2/py3 compatible load of SafeConfigParser/ConfigParser
+import pathlib
 from configparser import ConfigParser
 
 from nose2 import config, events, util
@@ -120,11 +119,12 @@ class Session:
 
         """
         for filename in filenames:
-            if filename.endswith(".cfg"):
-                self.config.read(filename)
-            elif filename.endswith("pyproject.toml"):
-                if not os.path.exists(filename):
-                    continue
+            path = pathlib.Path(filename)
+            if not path.exists():
+                continue
+
+            # handle pyproject.toml case
+            if path.name == "pyproject.toml":
                 toml_config = load_toml(filename)
                 if not isinstance(toml_config.get("tool"), dict):
                     continue
@@ -132,6 +132,10 @@ class Session:
                 if not isinstance(tool_table.get("nose2"), dict):
                     continue
                 self.config.read_dict(tool_table["nose2"])
+
+            # else, use the config parser to read config data
+            else:
+                self.config.read(path)
 
     def loadPlugins(self, modules=None, exclude=None):
         """Load plugins.

--- a/nose2/tests/functional/test_session.py
+++ b/nose2/tests/functional/test_session.py
@@ -1,9 +1,30 @@
+import pathlib
 import sys
+import tempfile
 import unittest
 
 from nose2 import session
 from nose2._toml import TOML_ENABLED
 from nose2.tests._common import FunctionalTestCase, support_file
+
+
+def test_loading_config_from_ini_file_without_cfg_suffix():
+    """
+    Regression test for https://github.com/nose-devs/nose2/issues/614
+
+    It is possible to have nose2 config embedded in any ini config file, and it might
+    not have a recognizable name.
+    It is not guaranteed that filenames used for config will end in `.cfg`.
+    """
+    sess = session.Session()
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tmpdir = pathlib.Path(tmpdirname)
+
+        foo_ini = tmpdir / "foo.ini"
+        foo_ini.write_text("""[alpha]\na = 1""")
+
+        sess.loadConfigFiles(str(foo_ini))
+        assert sess.config.has_section("alpha")
 
 
 class SessionFunctionalTests(FunctionalTestCase):


### PR DESCRIPTION
The check for which config loading path to use incorrectly treated
'.cfg' as the only valid suffix for ini configs.
This is not the case for a config loaded with `-c`.

To fix, introduce a regression test, then make some strategic use of
pathlib to simplify path/file inspection and fix the issue.

fixes #614
