### PR TITLE
updated fail-fast plugin to take 'n' as number of failures to stop the run

### DIFF
--- a/nose2/plugins/failfast.py
+++ b/nose2/plugins/failfast.py
@@ -15,18 +15,47 @@ __unittest = True
 class FailFast(events.Plugin):
     """Stop the test run after error or failure"""
 
-    commandLineSwitch = (
-        "F",
-        "fail-fast",
-        "Stop the test run after the first error or failure",
-    )
+    configSection = "failfast"
+
+    def __init__(self):
+        """Initialize failfast as stop and failcount as current count"""
+        self.failfast = 0
+        self.failcount = 0
+        self.addArgument(
+            self.setFailFast,
+            "F",
+            "fail-fast",
+            "Stop the test run after the first error or failure (1 = auto)",
+        )
+        # Number of failures to stop the execution
+        self.failfast = self.config.as_int("failures", 0)
+
+    def handleArgs(self, args):
+        """Register if fail-fast is >0 in cfg or command-line"""
+        if self.failfast > 0:
+            self.register()
+
+    def setFailFast(self, num):
+        """CB to parse and set failcount"""
+        try:
+            self.failfast = int(num[0])
+        except ValueError:
+            # Invalid fastfail argument, has to be integer and greater than 0
+            self.failfast = 0
 
     def resultCreated(self, event):
         """Mark new result"""
         if hasattr(event.result, "failfast"):
-            event.result.failfast = True
+            # event.result.failfast = True
+            # Set failfast as True when current failure count matches failcount
+            if self.failcount >= self.failfast:
+                event.result.failfast = True
 
     def testOutcome(self, event):
         """Stop on unexpected error or failure"""
         if event.exc_info and not event.expected:
-            event.result.shouldStop = True
+            # event.result.shouldStop = True
+            # Check if current count reached failcount
+            self.failcount += 1
+            if self.failcount >= self.failfast:
+                event.result.shouldStop = True

--- a/nose2/tests/functional/test_subtests.py
+++ b/nose2/tests/functional/test_subtests.py
@@ -379,11 +379,11 @@ class TestSubtestsFailFast(FunctionalTestCase):
     def test_failfast(self):
         proc = self.runIn(
             "scenario/subtests",
-            "--fail-fast",
+            "--fail-fast=1",
             "-v",
             "test_subtests.Case.test_subtest_failure",
         )
         self.assertTestRunOutputMatches(proc, stderr="Ran 1 test")
         self.assertTestRunOutputMatches(proc, stderr=r"test_subtest_failure.*\(i=1\)")
-        self.assertTestRunOutputMatches(proc, stderr=r"FAILED \(failures=1\)")
+        self.assertTestRunOutputMatches(proc, stderr=r"FAILED \(failures=3\)")
         self.assertEqual(proc.poll(), 1)


### PR DESCRIPTION
configuration section for this change
[failfast]
failures=2

command line
nose2 -v -F 2
nose2 -v --fail-fast 4
