### PR TITLE
plugins/mp: set context to fork for Python 3.14 mp API changes

### DIFF
--- a/nose2/plugins/mp.py
+++ b/nose2/plugins/mp.py
@@ -15,6 +15,17 @@ from nose2 import events, loader, result, runner, session, util
 log = logging.getLogger(__name__)
 
 
+# Python 3.14: Change in multiprocessing API
+# https://docs.python.org/3/library/multiprocessing.html
+# #multiprocessing-start-methods
+# On POSIX platforms the default start method was changed from fork to
+# forkserver to retain the performance but avoid common multithreaded
+# process incompatibilities.
+# [...]
+# set_start_method() should not be used more than once in the program.
+multiprocessing.set_start_method("fork")
+
+
 class MultiProcess(events.Plugin):
     configSection = "multiprocess"
 


### PR DESCRIPTION
This commit sets the Python built-in multiprocessing library context to multiprocessing.context.ForkContext.
This is needed due to a change in its API from Python 3.14:
> Changed in version 3.14: On POSIX platforms the default start method was
> changed from fork to forkserver to retain the performance but avoid
> common multithreaded process incompatibilities. See gh-84559.

Note that the change is done in the "mp" module itself and not in its MultiProcess class since the multiprocessing context can be set only once.