### PR TITLE
Update to handle typing of pkg_resources

### DIFF
--- a/nose2/plugins/loader/eggdiscovery.py
+++ b/nose2/plugins/loader/eggdiscovery.py
@@ -25,7 +25,7 @@ __unittest = True
 log = logging.getLogger(__name__)
 
 try:
-    import pkg_resources
+    import pkg_resources  # type: ignore[import-untyped]
 
     _has_pkg_resources = True
 except ImportError:

--- a/nose2/tests/functional/test_eggdiscovery_loader.py
+++ b/nose2/tests/functional/test_eggdiscovery_loader.py
@@ -6,7 +6,7 @@ import nose2.plugins.loader.eggdiscovery  # noqa: F401
 from nose2.tests._common import FunctionalTestCase, support_file
 
 try:
-    import pkg_resources  # noqa: F401
+    import pkg_resources  # type: ignore[import-untyped]  # noqa: F401
 except ImportError:
     pass
 else:


### PR DESCRIPTION
With `pkg_resources` no longer included in `setuptools`, it also is
removed from the type stubs.
