### PR TITLE
Fix `TestPluginApi::test_add_option_adds_option` test for Python 3.14

### DIFF
--- a/nose2/tests/unit/test_plugin_api.py
+++ b/nose2/tests/unit/test_plugin_api.py
@@ -17,7 +17,7 @@ class TestPluginApi(TestCase):
 
     def test_add_option_adds_option(self):
         helpt = self.session.argparse.format_help()
-        assert "-X, --xxx" in helpt, (
+        assert "-X" in helpt and "--xxx" in helpt, (
             "commandLineSwitch arg not found in help text: %s" % helpt
         )
 


### PR DESCRIPTION
Starting with Python 3.14, both `-X` and `--xxx` are surrounded by ANSI color codes in the argparse help text. To avoid matching on these, check that both `-X` and `--xxx` are present in `helpt` individually.

Logs where the test fails: https://hydra.nixos.org/build/321470625/nixlog/4