### PR TITLE
Improve tox config to remove 'nocov', add 'mp'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 branch = True
 omit = nose2/tests/*
 include = nose2/*
+parallel = True
 
 [report]
 show_missing = True

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,4 +65,5 @@ jobs:
       - name: install tox
         run: python -m pip install -U tox
       - name: test
-        run: python -m tox -e py
+        run: |
+          python -m tox -m ci

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,46 @@
 [tox]
-envlist=py{38,39,310,311,312,313,314}{,-nocov},pypy,docs,lint
+envlist=
+    lint
+    mypy
+    docs
+    covclean
+    py{38,39,310,311,312,313,314},pypy
+    covcombine
+    covreport
+labels =
+    ci = py,covcombine,covreport
 
 [testenv]
 passenv = CI
 extras = dev
 deps =
-    !nocov: coverage
+    coverage
     py{38,39,310}-toml: tomli
 setenv = PYTHONPATH={toxinidir}
 commands =
-    nocov: nose2 -v --pretty-assert {posargs}
-    !nocov: coverage erase
-    !nocov: coverage run nose2 -v --pretty-assert {posargs}
-    !nocov: coverage report
+    !mp: coverage run nose2 -v --pretty-assert {posargs}
+    mp: coverage run nose2 -v --plugin nose2.plugins.mp -N 0 {posargs}
+
+depends =
+    py{,py,38,39,310,311,312,313,314}{,-mp,-toml}: covclean
+    covcombine: py{,py,38,39,310,311,312,313,314}{,-mp,-toml}
+    covreport: covcombine
+
+[testenv:covclean]
+deps = coverage
+skip_install = true
+commands = coverage erase
+
+[testenv:covcombine]
+deps = coverage
+skip_install = true
+commands = coverage combine
+
+[testenv:covreport]
+deps = coverage
+skip_install = true
+commands_pre = coverage html --fail-under=0
+commands = coverage report
 
 [testenv:lint]
 deps = pre-commit~=4.4.0


### PR DESCRIPTION
- Coverage plugin is going away, no longer any call for "nocov" testing.
- `mp` factor doesn't work yet, but will let us confirm that running
  under `mp` in a real testsuite works properly.
