### PR TITLE
Use a dedicated multiprocessing context (of type "fork")

### DIFF
--- a/nose2/plugins/mp.py
+++ b/nose2/plugins/mp.py
@@ -16,7 +16,9 @@ from nose2 import events, loader, result, runner, session, util
 log = logging.getLogger(__name__)
 
 if platform.system() == "Windows":
-    MP_CTX = multiprocessing.get_context("spawn")
+    MP_CTX: (
+        multiprocessing.context.ForkContext | multiprocessing.context.SpawnContext
+    ) = multiprocessing.get_context("spawn")
 else:
     MP_CTX = multiprocessing.get_context("fork")
 


### PR DESCRIPTION
In order to ensure that `nose2` isn't harmed by or harmful to users who set the
multiprocessing process start method (globally), it now uses a multiprocessing
context for the "mp" (multiprocess) plugin.

This also ensures that `nose2` continues to use "fork" on Python 3.14+.
