### PR TITLE
docs: update 9 outdated and deprecated URLs across docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,7 +181,7 @@ If you want to make contributions, please read the `contributing`_ guide.
 
 .. _changelog: https://docs.nose2.io/en/latest/changelog.html
 
-.. _pytest: http://pytest.readthedocs.io/en/latest/
+.. _pytest: https://docs.pytest.org/en/latest/
 
 .. _contributing: https://github.com/nose-devs/nose2/blob/main/contributing.rst
 

--- a/contributing.rst
+++ b/contributing.rst
@@ -62,5 +62,5 @@ have ``pre-commit`` installed and run:
 .. _black: https://black.readthedocs.io/
 .. _github: https://github.com/nose-devs/nose2
 .. _pre-commit: https://pre-commit.com/
-.. _ruff: https://beta.ruff.rs/docs/
-.. _tox: http://pypi.python.org/pypi/tox
+.. _ruff: https://docs.astral.sh/ruff/
+.. _tox: https://pypi.org/project/tox/

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -146,7 +146,7 @@ these options somewhere. Plugins that want to make use of nose2's
 *must* extract all of their config values in their ``__init__``
 methods.
 
-.. _Sphinx : http://sphinx.pocoo.org/
+.. _Sphinx : https://www.sphinx-doc.org/
 
 
 Test Runner Tips and Tweaks

--- a/docs/dev/documenting_plugins.rst
+++ b/docs/dev/documenting_plugins.rst
@@ -30,4 +30,4 @@ docs explaining what your plugin does and how to use it. You can put
 those words in the ``*.rst`` file itself, or in the docstring of the module
 where your plugin lives.
 
-.. _Sphinx : http://sphinx.pocoo.org/
+.. _Sphinx : https://www.sphinx-doc.org/

--- a/docs/dev/writing_plugins.rst
+++ b/docs/dev/writing_plugins.rst
@@ -214,5 +214,5 @@ Recipes
 
   Example: :class:`nose2.plugins.loader.parameters.Parameters`
 
-.. _argparse : http://pypi.python.org/pypi/argparse/1.2.1
-.. _Sphinx : http://sphinx.pocoo.org/
+.. _argparse : https://docs.python.org/3/library/argparse.html
+.. _Sphinx : https://www.sphinx-doc.org/

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -34,5 +34,5 @@ The ``nose2`` script supports a number of command-line options, as
 well as extensive configuration via config files. For more information
 see :doc:`usage` and :doc:`configuration`.
 
-.. _pip : http://pypi.python.org/pypi/pip/1.0.2
-.. _pypi : http://pypi.python.org/pypi
+.. _pip : https://pip.pypa.io/
+.. _pypi : https://pypi.org/


### PR DESCRIPTION
## What

Replace 9 outdated/deprecated links across 6 documentation files.

## Why

Several URLs in the docs either redirect to stale content or point to domains that no longer exist at those paths:

| File | Old URL | New URL |
|------|---------|---------|
| `contributing.rst` | `https://beta.ruff.rs/docs/` | `https://docs.astral.sh/ruff/` |
| `contributing.rst` | `http://pypi.python.org/pypi/tox` | `https://pypi.org/project/tox/` |
| `README.rst` | `http://pytest.readthedocs.io/en/latest/` | `https://docs.pytest.org/en/latest/` |
| `docs/dev/writing_plugins.rst` | `http://pypi.python.org/pypi/argparse/1.2.1` | `https://docs.python.org/3/library/argparse.html` |
| `docs/dev/writing_plugins.rst` | `http://sphinx.pocoo.org/` | `https://www.sphinx-doc.org/` |
| `docs/dev/documenting_plugins.rst` | `http://sphinx.pocoo.org/` | `https://www.sphinx-doc.org/` |
| `docs/getting_started.rst` | `http://pypi.python.org/pypi/pip/1.0.2` | `https://pip.pypa.io/` |
| `docs/getting_started.rst` | `http://pypi.python.org/pypi` | `https://pypi.org/` |
| `docs/configuration.rst` | `http://sphinx.pocoo.org/` | `https://www.sphinx-doc.org/` |

Notable changes:
- **Ruff**: `beta.ruff.rs` was the staging URL before the 0.1.0 stable release; the canonical docs are now at `docs.astral.sh/ruff`
- **argparse**: has been part of Python stdlib since 3.2; the PyPI page is a stub pointing to the stdlib docs
- **Sphinx**: moved from `sphinx.pocoo.org` to `www.sphinx-doc.org` years ago
- **PyPI**: `pypi.python.org` was the legacy URL before the 2018 warehouse migration to `pypi.org`
- **pytest**: `pytest.readthedocs.io` now redirects to `docs.pytest.org`

## How verified

Checked that all new URLs resolve correctly. This is a pure documentation change with no code modifications.
