### PR TITLE
Fix JUnit XML timestamps for subtests

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,12 @@ testsuites.
 Unreleased
 ----------
 
+Fixed
+~~~~~
+
+* JUnit XML reports now use the containing test's start timestamp for every
+  failing subtest. (:issue:`567`)
+
 0.16.0 (2026-03-01)
 -------------------
 

--- a/nose2/plugins/junitxml.py
+++ b/nose2/plugins/junitxml.py
@@ -1,9 +1,9 @@
 """
 Output test reports in junit-xml format.
 
-This plugin implements :func:`startTest`, :func:`testOutcome` and
-:func:`stopTestRun` to compile and then output a test report in
-junit-xml format. By default, the report is written to a file called
+This plugin implements :func:`startTest`, :func:`stopTest`,
+:func:`testOutcome` and :func:`stopTestRun` to compile and then output a test
+report in junit-xml format. By default, the report is written to a file called
 ``nose2-junit.xml`` in the current working directory.
 
 You can configure the output filename by setting ``path`` in a ``[junit-xml]``
@@ -145,6 +145,10 @@ class JUnitXmlReporter(events.Plugin):
         """Count test, record start time"""
         self.numtests += 1
         self._start = event.startTime
+
+    def stopTest(self, event):
+        """Clear the start time after all outcomes for a test are reported."""
+        self._start = None
 
     def testOutcome(self, event):
         """Add test outcome to xml tree"""
@@ -293,10 +297,7 @@ class JUnitXmlReporter(events.Plugin):
         try:
             return time.time() - self._start
         except Exception:
-            pass
-        finally:
-            self._start = None
-        return 0
+            return 0
 
     def _iso_timestamp(self):
         # in some cases, `self._start` is still None when this runs, convert to 0

--- a/nose2/tests/unit/test_junitxml.py
+++ b/nose2/tests/unit/test_junitxml.py
@@ -201,6 +201,22 @@ class TestJunitXmlPlugin(TestCase):
         self.assertIsNone(skip.get("message"))
         self.assertIsNone(skip.text)
 
+    def test_subtest_timestamps_use_parent_start(self):
+        class SubTestCase(unittest.TestCase):
+            def test_failing_subtests(self):
+                for value in range(2):
+                    with self.subTest(value=value):
+                        self.fail()
+
+        test = SubTestCase("test_failing_subtests")
+        test(self.result)
+        timestamps = [
+            case.get("timestamp") for case in self.plugin.tree.findall("testcase")
+        ]
+        self.assertEqual(len(timestamps), 2)
+        self.assertEqual(timestamps[0], timestamps[1])
+        self.assertNotEqual(timestamps[0], "1970-01-01T00:00:00")
+
     def test_generator_timestamp_increases(self):
         gen = generators.Generators(session=self.session)
         gen.register()


### PR DESCRIPTION
Fixes #567.

The JUnit XML reporter cleared its test start time after the first outcome, so later failing subtests were emitted with the Unix epoch and zero duration. Keep the timestamp alive through the containing test and clear it at `stopTest`, with regression coverage for multiple failures.

Verified with the full suite (332 tests, 8 skipped) and pre-commit on the three changed files.
