### PR TITLE
fix: avoid UnboundLocalError when a plugin clears event.names

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,10 @@ Fixed
 * JUnit XML reports now use the containing test's start timestamp for every
   failing subtest. (:issue:`567`)
 
+* ``PluggableTestLoader.loadTestsFromNames`` no longer raises
+  ``UnboundLocalError`` when a plugin clears ``event.names`` without setting
+  ``event.handled``. An empty suite is loaded instead. (:issue:`445`)
+
 0.16.0 (2026-03-01)
 -------------------
 

--- a/nose2/loader.py
+++ b/nose2/loader.py
@@ -64,6 +64,8 @@ class PluggableTestLoader:
                 suites = [self.loadTestsFromName(name, module) for name in event.names]
             elif module:
                 suites = self.loadTestsFromModule(module)
+            else:
+                suites = []
         if event.extraTests:
             suites.extend(event.extraTests)
         return self.suiteClass(suites)

--- a/nose2/tests/unit/test_loader.py
+++ b/nose2/tests/unit/test_loader.py
@@ -74,6 +74,13 @@ class TestPluggableTestLoader(TestCase):
             "FakePlugin.loadTestsFromNames() was not called",
         )
 
+    def test_loader_from_names_without_names_or_module(self):
+        # a plugin may clear event.names without setting event.handled,
+        # which must produce an empty suite rather than UnboundLocalError
+        self.session.hooks.register("loadTestsFromNames", NameClearingPlugin())
+        suite = self.loader.loadTestsFromNames(["some_name"])
+        self.assertEqual(list(suite), [])
+
 
 class FakePlugin:
     def __init__(self) -> None:
@@ -92,3 +99,8 @@ class FakePlugin:
     def loadTestsFromNames(self, event):
         event.fakeLoadFromNames = True
         self.fakeLoadFromNames = True
+
+
+class NameClearingPlugin:
+    def loadTestsFromNames(self, event):
+        event.names = []


### PR DESCRIPTION
Closes #445

If a `loadTestsFromNames` plugin clears `event.names` without setting `event.handled`, neither branch in `PluggableTestLoader.loadTestsFromNames` assigns `suites`, so the call raises `UnboundLocalError: local variable 'suites' referenced before assignment`. Defaulting `suites` to an empty list loads an empty suite instead, which is the behaviour the issue asks for.

Added a regression test registering a plugin that clears `event.names`; it fails with the reported `UnboundLocalError` without the loader change and passes with it.
