### PR TITLE
test: cover SkipTest raised in setUpClass

### DIFF
--- a/nose2/tests/functional/support/scenario/skip_in_class_setup/test_skip_in_setupclass.py
+++ b/nose2/tests/functional/support/scenario/skip_in_class_setup/test_skip_in_setupclass.py
@@ -1,0 +1,26 @@
+import unittest
+
+
+class SkipInSetUpClass(unittest.TestCase):
+    """SkipTest from setUpClass should skip the class, not error.
+
+    Regression coverage for issue #373: this was reported as an error
+    (an ``_ErrorHolder`` failure) rather than a skip.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        raise unittest.SkipTest("skipping the whole class")
+
+    def test_not_run_1(self):
+        raise AssertionError("setUpClass skipped; this must never run")
+
+    def test_not_run_2(self):
+        raise AssertionError("setUpClass skipped; this must never run")
+
+
+class SkipInSetUpModuleSibling(unittest.TestCase):
+    """A normal class in the same module still runs."""
+
+    def test_runs(self):
+        self.assertTrue(True)

--- a/nose2/tests/functional/test_loading.py
+++ b/nose2/tests/functional/test_loading.py
@@ -335,3 +335,15 @@ class TestTestClassLoading(FunctionalTestCase):
                 r"FAILED \(failures=1, expected failures=1, unexpected successes=1\)"
             ),
         )
+
+
+class TestSkipTestInSetUpClass(FunctionalTestCase):
+    """SkipTest raised in setUpClass is a skip, not an error (issue #373)."""
+
+    def test_skiptest_in_setupclass_is_reported_as_skip(self):
+        proc = self.runIn("scenario/skip_in_class_setup", "-v")
+        self.assertTestRunOutputMatches(proc, stderr=r"OK \(skipped=1\)")
+        self.assertTestRunOutputMatches(proc, stderr=r"skipping the whole class")
+        # The skipped class must not be reported as an error.
+        self.assertTestRunOutputMatches(proc, stderr=r"Ran 1 test")
+        self.assertEqual(proc.poll(), 0)


### PR DESCRIPTION
Related: #373

## What this is

Regression coverage, not a fix. `SkipTest` raised in `setUpClass` already behaves correctly on `main` — I verified it before writing anything:

```
$ cat test_skipcls.py
import unittest

class Failing(unittest.TestCase):
    @classmethod
    def setUpClass(cls):
        raise unittest.SkipTest("skip whole class")

    def test_ignored(self):
        self.assertTrue(1)

$ python -m nose2 -v
_ErrorHolder ... skipped skip whole class
Ran 0 tests in 0.000s
OK (skipped=1)          # exit 0
```

The reported failure mode (the class reported as an `ERROR` via `_ErrorHolder`, exit non-zero) does not occur on 0.16.0.

What was never done is the thing @katrinabrock asked for in the issue thread:

> This functionality should get tested here: `.../scenario/tests_in_package/pkg1/test/test_things.py` (but with unittest not unittest2)

That scenario has `test_skippy`, a skipping *test method*, but nothing covering a skip raised from `setUpClass`. So the behavior is correct and completely unpinned, which is presumably how the issue stayed open while the underlying bug quietly got fixed.

## Approach

I put the fixture in a new `scenario/skip_in_class_setup/` rather than adding to `tests_in_package` as suggested. Six functional modules load that scenario and several assert on exact counts (`Ran 25 tests`), so adding classes there means updating unrelated expectations in the same PR. A dedicated scenario keeps the diff additive.

The fixture asserts the negative too: both methods in the skipped class raise `AssertionError` if they ever execute, so a regression that runs tests after a class-level skip fails loudly instead of just changing a count. A sibling class in the same module verifies the skip does not leak to unrelated tests.

## Testing

`nose2/tests/functional/test_loading.py`: 37 passed with this change, 36 on `main`. The new test asserts `OK (skipped=1)`, `Ran 1 test`, the skip reason text, and exit status 0.

No changelog entry: this adds no user-facing behavior change.
